### PR TITLE
fix: update CLI name to leanproxy-mcp and add automatic version management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,29 +40,21 @@ test-coverage: test ## Run tests with coverage report
 build: tidy ## Build all platform binaries to dist/
 	@echo "Building for all platforms..."
 	@mkdir -p $(DIST_DIR)
-	GOOS=darwin GOARCH=amd64 $(GO) build -ldflags="-s -w" -o $(DIST_DIR)/$(BINARY_NAME)-darwin-amd64 .
-	GOOS=darwin GOARCH=arm64 $(GO) build -ldflags="-s -w" -o $(DIST_DIR)/$(BINARY_NAME)-darwin-arm64 .
-	GOOS=linux GOARCH=amd64 $(GO) build -ldflags="-s -w" -o $(DIST_DIR)/$(BINARY_NAME)-linux-amd64 .
-	GOOS=linux GOARCH=arm64 $(GO) build -ldflags="-s -w" -o $(DIST_DIR)/$(BINARY_NAME)-linux-arm64 .
-	GOOS=windows GOARCH=amd64 $(GO) build -ldflags="-s -w" -o $(DIST_DIR)/$(BINARY_NAME)-windows-amd64.exe .
+	VERSION=$(VERSION) COMMIT=$(COMMIT) BUILD_TIME=$(BUILD_TIME) $(GO) build -ldflags="$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY_NAME)-darwin-amd64 .
+	VERSION=$(VERSION) COMMIT=$(COMMIT) BUILD_TIME=$(BUILD_TIME) $(GO) build -ldflags="$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY_NAME)-darwin-arm64 .
+	VERSION=$(VERSION) COMMIT=$(COMMIT) BUILD_TIME=$(BUILD_TIME) $(GO) build -ldflags="$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY_NAME)-linux-amd64 .
+	VERSION=$(VERSION) COMMIT=$(COMMIT) BUILD_TIME=$(BUILD_TIME) $(GO) build -ldflags="$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY_NAME)-linux-arm64 .
+	VERSION=$(VERSION) COMMIT=$(COMMIT) BUILD_TIME=$(BUILD_TIME) $(GO) build -ldflags="$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY_NAME)-windows-amd64.exe .
 	@echo "Builds available in $(DIST_DIR)/"
 
 .PHONY: build-local
 build-local: tidy ## Build for current platform only
 	@echo "Building for $(shell go env GOOS)/$(shell go env GOARCH)..."
 	@mkdir -p $(DIST_DIR)
-	$(GO) build -ldflags="-s -w" -o $(DIST_DIR)/$(BINARY_NAME) .
+	VERSION=$(VERSION) COMMIT=$(COMMIT) BUILD_TIME=$(BUILD_TIME) $(GO) build -ldflags="$(LDFLAGS)" -o $(DIST_DIR)/$(BINARY_NAME) .
 
 .PHONY: build-version
-build-version: tidy ## Build with custom version (VERSION=x.x.x)
-	@echo "Building version $(VERSION)..."
-	@mkdir -p $(DIST_DIR)
-	GOOS=darwin GOARCH=amd64 $(GO) build -ldflags="-s -w -X main.version=$(VERSION)" -o $(DIST_DIR)/$(BINARY_NAME)-darwin-amd64 .
-	GOOS=darwin GOARCH=arm64 $(GO) build -ldflags="-s -w -X main.version=$(VERSION)" -o $(DIST_DIR)/$(BINARY_NAME)-darwin-arm64 .
-	GOOS=linux GOARCH=amd64 $(GO) build -ldflags="-s -w -X main.version=$(VERSION)" -o $(DIST_DIR)/$(BINARY_NAME)-linux-amd64 .
-	GOOS=linux GOARCH=arm64 $(GO) build -ldflags="-s -w -X main.version=$(VERSION)" -o $(DIST_DIR)/$(BINARY_NAME)-linux-arm64 .
-	GOOS=windows GOARCH=amd64 $(GO) build -ldflags="-s -w -X main.version=$(VERSION)" -o $(DIST_DIR)/$(BINARY_NAME)-windows-amd64.exe .
-	@echo "Version $(VERSION) builds available in $(DIST_DIR)/"
+build-version: build ## Build with custom version (overrides git tag)
 
 .PHONY: clean
 clean: ## Remove build artifacts
@@ -73,7 +65,7 @@ clean: ## Remove build artifacts
 .PHONY: install
 install: tidy ## Build and install to GOPATH/bin
 	@echo "Installing to $(GOPATH)/bin..."
-	$(GO) install -ldflags="-s -w" .
+	VERSION=$(VERSION) COMMIT=$(COMMIT) BUILD_TIME=$(BUILD_TIME) $(GO) install -ldflags="$(LDFLAGS)" .
 
 .PHONY: run
 run: ## Run the application (ARGS='serve --help')
@@ -125,4 +117,6 @@ GOPATH := $(shell go env GOPATH)
 
 LATEST_TAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "")
 VERSION ?= $(LATEST_TAG)
-DEFAULT_VERSION := 0.1.0
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "")
+BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+LDFLAGS := -s -w -X github.com/mmornati/leanproxy-mcp/internal/version.Version=$(VERSION) -X github.com/mmornati/leanproxy-mcp/internal/version.Commit=$(COMMIT) -X github.com/mmornati/leanproxy-mcp/internal/version.BuildTime=$(BUILD_TIME)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,7 @@ import (
 )
 
 var RootCmd = &cobra.Command{
-	Use:   "leanproxy",
+	Use:   "leanproxy-mcp",
 	Short: "LeanProxy MCP - A JSON-RPC streaming proxy with token validation",
 	Long: `LeanProxy MCP provides secure JSON-RPC streaming proxy capabilities
 with token validation, MCP server registry, and configurable redaction.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,15 +3,14 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/mmornati/leanproxy-mcp/internal/version"
 	"github.com/spf13/cobra"
 )
-
-var versionString = "0.1.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
-	Long:  `Print the version and build information for leanproxy.`,
+	Long:  `Print the version and build information for leanproxy-mcp.`,
 	Run:   runVersion,
 }
 
@@ -20,5 +19,9 @@ func init() {
 }
 
 func runVersion(cmd *cobra.Command, args []string) {
-	fmt.Printf("leanproxy version %s\n", versionString)
+	v := version.Get()
+	fmt.Printf("leanproxy-mcp version %s\n", v.Version)
+	fmt.Printf("build date: %s\n", v.BuildTime)
+	fmt.Printf("platform: %s\n", v.Platform)
+	fmt.Printf("go: %s\n", v.GoVersion)
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -613,7 +613,7 @@ Generate shell completion scripts.
 ### Usage
 
 ```bash
-leanproxy completion [shell]
+leanproxy-mcp completion [shell]
 ```
 
 ### Arguments
@@ -629,13 +629,13 @@ leanproxy completion [shell]
 
 ```bash
 # Bash
-leanproxy completion bash > /etc/bash_completion.d/leanproxy
+leanproxy-mcp completion bash > /etc/bash_completion.d/leanproxy-mcp
 
 # Zsh
-leanproxy completion zsh > ~/.zsh/completions/_leanproxy
+leanproxy-mcp completion zsh > ~/.zsh/completions/_leanproxy-mcp
 
 # Fish
-leanproxy completion fish > ~/.config/fish/completions/leanproxy.fish
+leanproxy-mcp completion fish > ~/.config/fish/completions/leanproxy-mcp.fish
 ```
 
 ---
@@ -647,14 +647,16 @@ Print version information.
 ### Usage
 
 ```bash
-leanproxy version
+leanproxy-mcp version
 ```
 
 #### Output
 
 ```
- leanproxy-mcp version 0.2.0
+ leanproxy-mcp version v0.2.0
  build date: 2026-05-01
+ platform: darwin/arm64
+ go: go1.26.2
 ```
 
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -170,12 +170,12 @@ Make sure LeanProxy is in your PATH:
 
 ```bash
 # Verify installation
-leanproxy version
+leanproxy-mcp version
 
 # If not found, check installation
-which leanproxy
+which leanproxy-mcp
 # or
-where leanproxy
+where leanproxy-mcp
 ```
 
 ### Server won't start

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -86,13 +86,15 @@ sudo make install
 ## Verify Installation
 
 ```bash
-leanproxy version
+leanproxy-mcp version
 ```
 
 Expected output:
 ```
- leanproxy-mcp version 0.2.0
+ leanproxy-mcp version v0.2.0
  build date: 2026-05-01
+ platform: darwin/arm64
+ go: go1.26.2
 ```
 
 ## IDE Configuration
@@ -136,13 +138,13 @@ Generate shell completions for your shell:
 
 ```bash
 # Bash
-leanproxy completion bash > /etc/bash_completion.d/leanproxy
+leanproxy-mcp completion bash > /etc/bash_completion.d/leanproxy-mcp
 
 # Zsh
-leanproxy completion zsh > ~/.zsh/completions/_leanproxy
+leanproxy-mcp completion zsh > ~/.zsh/completions/_leanproxy-mcp
 
 # Fish
-leanproxy completion fish > ~/.config/fish/completions/leanproxy.fish
+leanproxy-mcp completion fish > ~/.config/fish/completions/leanproxy-mcp.fish
 ```
 
 ## Next Steps

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,48 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+)
+
+var (
+	Version   = "dev"
+	Commit   = ""
+	BuildTime = "unknown"
+	BuiltBy  = "unknown"
+)
+
+type Info struct {
+	Version   string `json:"version"`
+	Commit   string `json:"commit"`
+	BuildTime string `json:"buildTime"`
+	BuiltBy  string `json:"builtBy"`
+	GoVersion string `json:"goVersion"`
+	Platform string `json:"platform"`
+}
+
+func Get() Info {
+	bi, ok := debug.ReadBuildInfo()
+	goVersion := runtime.Version()
+	if ok {
+		goVersion = bi.GoVersion
+	}
+
+	return Info{
+		Version:   Version,
+		Commit:    Commit,
+		BuildTime: BuildTime,
+		BuiltBy:   BuiltBy,
+		GoVersion: goVersion,
+		Platform:  runtime.GOOS + "/" + runtime.GOARCH,
+	}
+}
+
+func VersionString() string {
+	v := Get()
+	if v.Commit != "" {
+		return fmt.Sprintf("%s (%s)", v.Version, v.Commit)
+	}
+	return v.Version
+}


### PR DESCRIPTION
## Summary
- Rename CLI binary from `leanproxy` to `leanproxy-mcp` to match release naming convention
- Implement automatic version injection via ldflags during build (no manual source editing needed)
- Update documentation to use correct command names

## Changes

### CLI Binary Name
- **Before**: `leanproxy` 
- **After**: `leanproxy-mcp`

This aligns CLI with the actual release binary naming convention published on GitHub releases.

### Automatic Version Management
- Created `internal/version/version.go` package that injects version info at build time via ldflags
- Version Variables:
  - `Version` - from git tag (`git describe --tags --abbrev=0`)
  - `Commit` - from git commit (`git rev-parse --short HEAD`)
  - `BuildTime` - ISO8601 timestamp

- Updated Makefile LDFLAGS:
  ```makefile
  LDFLAGS := -s -w \
    -X github.com/mmornati/leanproxy-mcp/internal/version.Version=$(VERSION) \
    -X github.com/mmornati/leanproxy-mcp/internal/version.Commit=$(COMMIT) \
    -X github.com/mmornati/leanproxy-mcp/internal/version.BuildTime=$(BUILD_TIME)
  ```

### Usage
```bash
# Uses latest git tag automatically
make build

# Override version
make build VERSION=v1.0.0

# Tag and release
make release VERSION=v0.2.0
```

### Version Output
```
leanproxy-mcp version v0.2.0
build date: 2026-05-03T13:36:34Z
platform: darwin/arm64
go: go1.26.2
```

### Documentation Updates
- Updated all command references from `leanproxy` to `leanproxy-mcp`
- Updated version output examples

## Breaking Change
Users with existing `leanproxy` CLI will need to update to `leanproxy-mcp` in their configurations.