### PR TITLE
fix: update GoReleaser ldflags for correct version injection

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/mmornati/leanproxy-mcp/cmd.versionString={{.Version}}
+      - -X github.com/mmornati/leanproxy-mcp/internal/version.Version={{.Version}}
+      - -X github.com/mmornati/leanproxy-mcp/internal/version.Commit={{.Commit}}
+      - -X github.com/mmornati/leanproxy-mcp/internal/version.BuildTime={{.Date "2006-01-02T15:04:05Z07:00"}}
 archives:
   - id: default
     formats: ["tar.gz"]


### PR DESCRIPTION
## Summary
Fix GoReleaser configuration to inject version information correctly at build time.

## Problem
The GitHub release binaries show `version: dev` and `build date: unknown` because:
1. Variable path was wrong: `cmd.versionString` instead of `internal/version.Version`
2. Only injected version, missing Commit and BuildTime

## Solution
Update `.goreleaser.yml` ldflags:
```yaml
ldflags:
  - -s -w
  - -X github.com/mmornati/leanproxy-mcp/internal/version.Version={{.Version}}
  - -X github.com/mmornati/leanproxy-mcp/internal/version.Commit={{.Commit}}
  - -X github.com/mmornati/leanproxy-mcp/internal/version.BuildTime={{.Date "2006-01-02T15:04:05Z07:00"}}
```

GoReleaser provides these template variables:
- `{{.Version}}` - Release tag (e.g., v0.2.1)
- `{{.Commit}}` - Git commit SHA
- `{{.Date}}` - Build date