### PR TITLE
docs: update IDE configuration with MCP server configs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -126,17 +126,58 @@ Import to ~/.config/leanproxy_servers.yaml? [y/N]:
 
 Confirm to import the servers.
 
-### Step 2: Start LeanProxy
+### Step 2: Configure LeanProxy in Your IDE
 
-Start the LeanProxy server in a terminal:
+Configure LeanProxy as an MCP server in your IDE. LeanProxy runs as a daemon and proxies all your existing MCP servers through a single connection.
 
-```bash
-leanproxy-mcp serve
+#### OpenCode
+
+Add to your `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "leanproxy": {
+      "type": "local",
+      "command": ["leanproxy-mcp", "serve"],
+      "enabled": true
+    }
+  }
+}
 ```
 
-### Step 3: Configure Your IDE
+#### Cursor
 
-Connect your IDE to LeanProxy instead of individual MCP servers.
+Add to your `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "leanproxy": {
+      "command": "leanproxy-mcp",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+#### VS Code
+
+Add to your `~/.vscode/mcp.json` (create if it doesn't exist):
+
+```json
+{
+  "mcpServers": {
+    "leanproxy": {
+      "command": "leanproxy-mcp",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+> **Note:** When configured as an MCP server, LeanProxy automatically starts when your IDE connects. No need to run `leanproxy-mcp serve` manually.
 
 ## Shell Completions
 


### PR DESCRIPTION
## Summary

This PR updates the installation documentation (Step 2) to show how to configure LeanProxy as an MCP server in the major IDEs instead of manually running `leanproxy-mcp serve` in a terminal.

## Changes

### Before
The documentation showed running `leanproxy-mcp serve` manually in a terminal to start LeanProxy.

### After  
The documentation now shows IDE-specific MCP configuration for:

1. **OpenCode** (`~/.config/opencode/opencode.json`)
   - Uses the correct format with `"$schema"`, `"mcp"` key, `"type": "local"`, and `"enabled"` field
   - Based on user's local configuration

2. **Cursor** (`~/.cursor/mcp.json`)
   - Uses the standard `"mcpServers"` format
   - Based on user's local configuration

3. **VS Code** (`~/.vscode/mcp.json`)
   - Uses the standard `"mcpServers"` format

Removed sections:
- Manual terminal command (`leanproxy-mcp serve`)
- Redundant Step 3
- Claude Desktop (not installed locally to verify format)

## Note

When configured as an MCP server, LeanProxy automatically starts when the IDE connects. Users no longer need to manually run `leanproxy-mcp serve` in a terminal.