### PR TITLE
fix: remove list_servers tool from gateway schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In a 20-prompt coding session where GitHub is called only twice, Native MCP wast
 
 LeanProxy uses a gateway pattern with Just-In-Time schema loading:
 
-- **Single router schema**: Only 3 tools (`list_servers`, `invoke_tool`, `search_tools`) = **~160 tokens** vs 3,000+ for Native MCP
+- **Single router schema**: Only 2 tools (`invoke_tool`, `search_tools`) = **~110 tokens** vs 3,000+ for Native MCP
 - **On-demand tool registration**: Backend server schemas load only when actually invoked
 - **Session-aware caching**: Tool schemas persist across the session without per-request overhead
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Based on [data-driven analysis](https://blog.mornati.net/the-future-of-agentic-t
 
 LeanProxy uses a **gateway pattern** with JIT (Just-In-Time) schema loading:
 
-1. **Single router schema**: Only 3 tools (`list_servers`, `invoke_tool`, `search_tools`) = **~160 tokens** vs 3,000+ for Native MCP
+1. **Single router schema**: Only 2 tools (`invoke_tool`, `search_tools`) = **~110 tokens** vs 3,000+ for Native MCP
 2. **On-demand tool registration**: Backend server schemas only load when actually needed
 3. **Session-aware caching**: Tool schemas persist across the session without per-request overhead
 

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -21,12 +21,11 @@ func TestListTools(t *testing.T) {
 
 	tools := gw.ListTools()
 
-	if len(tools) != 3 {
-		t.Errorf("ListTools() returned %d tools, want 3", len(tools))
+	if len(tools) != 2 {
+		t.Errorf("ListTools() returned %d tools, want 2", len(tools))
 	}
 
 	expectedTools := map[string]bool{
-		"list_servers": false,
 		"invoke_tool":   false,
 		"search_tools": false,
 	}

--- a/pkg/gateway/tools.go
+++ b/pkg/gateway/tools.go
@@ -100,5 +100,5 @@ var searchToolsTool = Tool{
 }
 
 func (g *gatewayTools) ListTools() []Tool {
-	return []Tool{listServersTool, invokeToolTool, searchToolsTool}
+	return []Tool{invokeToolTool, searchToolsTool}
 }

--- a/pkg/utils/token_estimator.go
+++ b/pkg/utils/token_estimator.go
@@ -99,11 +99,6 @@ func (t *TokenEstimator) CalculateSavings(original, optimized string) (SavingsRe
 func (t *TokenEstimator) EstimateLeanProxySchemaTokens() int {
 	gatewayTools := []map[string]interface{}{
 		{
-			"name":        "list_servers",
-			"description": "List all MCP servers configured in this gateway",
-			"inputSchema": map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
-		},
-		{
 			"name":        "invoke_tool",
 			"description": "Invoke a tool on a specific MCP server",
 			"inputSchema": map[string]interface{}{


### PR DESCRIPTION
## Summary

The `list_servers` tool was defined in the gateway code but never actually exposed via the MCP API (it was only used internally). This PR removes it from the exposed schema and updates documentation.

## Changes

### Code Changes

| File | Change |
|------|--------|
| `pkg/gateway/tools.go` | Remove `listServersTool` from `ListTools()` return slice |
| `pkg/gateway/gateway_test.go` | Update `TestListTools` to expect 2 tools instead of 3 |
| `pkg/utils/token_estimator.go` | Update `EstimateLeanProxySchemaTokens()` to calculate for 2 tools (removing `list_servers` entry) |

### Documentation Changes

| File | Change |
|------|--------|
| `README.md` | Update line 29: "3 tools" → "2 tools", "160 tokens" → "110 tokens" |
| `docs/index.md` | Update line 70: "3 tools" → "2 tools", "160 tokens" → "110 tokens" |

## Token Estimate Verification

The token estimate was verified by calculating the actual JSON schema for both configurations:

```
3 tools: 578 chars → ~144 tokens (chars/4)
2 tools: 442 chars → ~110 tokens (chars/4)
```

Actual JSON schema for 2 tools (`invoke_tool`, `search_tools`):
```json
[
  {"description":"Invoke a tool on a specific MCP server","inputSchema":{...},"name":"invoke_tool"},
  {"description":"Search for tools across all configured MCP servers","inputSchema":{...},"name":"search_tools"}
]
```

## Why list_servers Was Removed

- The tool was defined in `tools.go` but `handleGatewayToolSync()` only dispatches for `invoke_tool` and `search_tools` (see `cmd/serve.go:344`: `isGatewayTool()`)
- `list_servers` was used internally for testing but not exposed as a gateway tool to MCP clients
- Removing it reduces schema overhead by ~34 tokens

## Testing

- All gateway package tests pass: `go test ./pkg/gateway/...`
- Full test suite passes