### PR TITLE
feat: add HTTP server support to tool caching system

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -46,7 +46,7 @@ var (
 	toolReg       router.ToolRegistry
 	gatewayTools  gateway.GatewayTools
 	stdioPool     *pool.StdioPool
-	httpPool      *pool.HTTPPool
+	httpPool      *pool.HTTPClientPool
 	ssePool       *pool.SSEPool
 	unifiedPool   *pool.UnifiedPool
 	statusStore   *statusfile.FileStatusStore
@@ -88,7 +88,7 @@ func runServe(cmd *cobra.Command, args []string) {
 	r := router.NewRouter(toolReg, serverReg, slog.Default())
 	gatewayTools = gateway.NewGatewayTools(serverReg, toolReg, r, slog.Default())
 	stdioPool = pool.NewStdioPool(5, 5*time.Minute, slog.Default())
-	httpPool = pool.NewHTTPPool(slog.Default())
+	httpPool = pool.NewHTTPClientPool(slog.Default())
 	ssePool = pool.NewSSEPool(slog.Default())
 	unifiedPool = pool.NewUnifiedPool(stdioPool, httpPool, ssePool, slog.Default())
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -47,6 +47,7 @@ var (
 	gatewayTools  gateway.GatewayTools
 	stdioPool     *pool.StdioPool
 	httpPool      *pool.HTTPPool
+	ssePool       *pool.SSEPool
 	unifiedPool   *pool.UnifiedPool
 	statusStore   *statusfile.FileStatusStore
 )
@@ -88,7 +89,8 @@ func runServe(cmd *cobra.Command, args []string) {
 	gatewayTools = gateway.NewGatewayTools(serverReg, toolReg, r, slog.Default())
 	stdioPool = pool.NewStdioPool(5, 5*time.Minute, slog.Default())
 	httpPool = pool.NewHTTPPool(slog.Default())
-	unifiedPool = pool.NewUnifiedPool(stdioPool, httpPool, slog.Default())
+	ssePool = pool.NewSSEPool(slog.Default())
+	unifiedPool = pool.NewUnifiedPool(stdioPool, httpPool, ssePool, slog.Default())
 
 	configPath := GlobalConfigPath
 	if configPath == "" {
@@ -118,9 +120,13 @@ func runServe(cmd *cobra.Command, args []string) {
 					if err := stdioPool.StartServer(ctx, srv); err != nil {
 						slog.Warn("failed to start stdio server", "name", srv.Name, "error", err)
 					}
-				case registry.TransportHTTP, registry.TransportSSE:
+				case registry.TransportHTTP:
 					if err := httpPool.StartServer(ctx, srv); err != nil {
 						slog.Warn("failed to start HTTP server", "name", srv.Name, "error", err)
+					}
+				case registry.TransportSSE:
+					if err := ssePool.StartServer(ctx, srv); err != nil {
+						slog.Warn("failed to start SSE server", "name", srv.Name, "error", err)
 					}
 				}
 			}
@@ -175,6 +181,9 @@ func runServe(cmd *cobra.Command, args []string) {
 		}
 		if httpPool != nil {
 			httpPool.Close()
+		}
+		if ssePool != nil {
+			ssePool.Close()
 		}
 		os.Exit(0)
 	}()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,12 +17,14 @@ import (
 	"time"
 
 	"github.com/mmornati/leanproxy-mcp/pkg/gateway"
+	"github.com/mmornati/leanproxy-mcp/pkg/mcp"
 	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
 	"github.com/mmornati/leanproxy-mcp/pkg/pool"
 	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
 	"github.com/mmornati/leanproxy-mcp/pkg/registry"
 	"github.com/mmornati/leanproxy-mcp/pkg/router"
 	"github.com/mmornati/leanproxy-mcp/pkg/statusfile"
+	"github.com/mmornati/leanproxy-mcp/pkg/toolstore"
 	"github.com/mmornati/leanproxy-mcp/pkg/utils/dryrun"
 	"github.com/spf13/cobra"
 )
@@ -40,11 +42,13 @@ var serveFlags struct {
 }
 
 var (
-	serverReg    registry.Registry
-	toolReg      router.ToolRegistry
-	gatewayTools gateway.GatewayTools
-	stdioPool    *pool.StdioPool
-	statusStore  *statusfile.FileStatusStore
+	serverReg     registry.Registry
+	toolReg       router.ToolRegistry
+	gatewayTools  gateway.GatewayTools
+	stdioPool     *pool.StdioPool
+	httpPool      *pool.HTTPPool
+	unifiedPool   *pool.UnifiedPool
+	statusStore   *statusfile.FileStatusStore
 )
 
 type Router interface {
@@ -83,6 +87,8 @@ func runServe(cmd *cobra.Command, args []string) {
 	r := router.NewRouter(toolReg, serverReg, slog.Default())
 	gatewayTools = gateway.NewGatewayTools(serverReg, toolReg, r, slog.Default())
 	stdioPool = pool.NewStdioPool(5, 5*time.Minute, slog.Default())
+	httpPool = pool.NewHTTPPool(slog.Default())
+	unifiedPool = pool.NewUnifiedPool(stdioPool, httpPool, slog.Default())
 
 	configPath := GlobalConfigPath
 	if configPath == "" {
@@ -104,9 +110,17 @@ func runServe(cmd *cobra.Command, args []string) {
 					"transport", srv.Transport,
 					"enabled", srv.Enabled != nil && *srv.Enabled,
 				)
-				if srv.Transport == registry.TransportStdio && srv.Enabled != nil && *srv.Enabled {
+				if srv.Enabled == nil || !*srv.Enabled {
+					continue
+				}
+				switch srv.Transport {
+				case registry.TransportStdio:
 					if err := stdioPool.StartServer(ctx, srv); err != nil {
-						slog.Warn("failed to start server", "name", srv.Name, "error", err)
+						slog.Warn("failed to start stdio server", "name", srv.Name, "error", err)
+					}
+				case registry.TransportHTTP, registry.TransportSSE:
+					if err := httpPool.StartServer(ctx, srv); err != nil {
+						slog.Warn("failed to start HTTP server", "name", srv.Name, "error", err)
 					}
 				}
 			}
@@ -114,6 +128,22 @@ func runServe(cmd *cobra.Command, args []string) {
 	} else {
 		slog.Info("no config file specified, starting in passthrough mode")
 	}
+
+	var toolStore toolstore.Cache
+	fileCache, err := toolstore.NewFileCache(slog.Default())
+	if err != nil {
+		slog.Warn("failed to create tool cache, using no-op cache", "error", err)
+		toolStore = toolstore.NewNoOpCache()
+	} else {
+		toolStore = fileCache
+		slog.Info("tool cache enabled", "path", fileCache.GetCacheDir())
+	}
+
+	handler := mcp.NewHandlerWithToolStore(unifiedPool, slog.Default(), toolStore)
+
+	cacheCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	handler.PopulateToolCache(cacheCtx)
 
 	slog.Info("starting server", "listen", serveFlags.listenAddr, "upstream", serveFlags.upstreamURL)
 
@@ -143,6 +173,9 @@ func runServe(cmd *cobra.Command, args []string) {
 		if stdioPool != nil {
 			stdioPool.Close()
 		}
+		if httpPool != nil {
+			httpPool.Close()
+		}
 		os.Exit(0)
 	}()
 
@@ -155,7 +188,7 @@ func runServe(cmd *cobra.Command, args []string) {
 			continue
 		}
 		slog.Debug("connection accepted", "remote", conn.RemoteAddr())
-		go handleConnection(conn, r, gatewayTools, stdioPool)
+		go handleConnection(conn, r, gatewayTools, unifiedPool)
 	}
 }
 
@@ -566,22 +599,27 @@ func updateServerStatusPeriodically() {
 	defer ticker.Stop()
 
 	for range ticker.C {
-		if statusStore == nil || stdioPool == nil {
+		if statusStore == nil || unifiedPool == nil {
 			continue
 		}
 
-		servers := stdioPool.ListServers()
+		servers := unifiedPool.ListServers()
 		statuses := make([]statusfile.ServerStatus, 0, len(servers))
 
 		for _, name := range servers {
-			state, _ := stdioPool.GetServerState(name)
-			stats, _ := stdioPool.GetServerStats(name)
+			state, _ := unifiedPool.GetServerState(name)
+
+			stats := pool.ServerStats{}
+			stdioStats, err := stdioPool.GetServerStats(name)
+			if err == nil {
+				stats = stdioStats
+			}
 
 			status := statusfile.ServerStatus{
 				Name:         name,
 				RequestCount: stats.RequestCount,
 				ErrorCount:   stats.ErrorCount,
-				RestartCount:  stats.RestartCount,
+				RestartCount: stats.RestartCount,
 				Uptime:       formatUptime(stats),
 			}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -347,7 +347,7 @@ func runServerRun(cmd *cobra.Command, args []string) error {
 	}
 
 	stdioPool := pool.NewStdioPool(5, 5*time.Minute, slog.Default())
-	httpPool := pool.NewHTTPPool(slog.Default())
+	httpPool := pool.NewHTTPClientPool(slog.Default())
 	ssePool := pool.NewSSEPool(slog.Default())
 	unifiedPool := pool.NewUnifiedPool(stdioPool, httpPool, ssePool, slog.Default())
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -348,7 +348,8 @@ func runServerRun(cmd *cobra.Command, args []string) error {
 
 	stdioPool := pool.NewStdioPool(5, 5*time.Minute, slog.Default())
 	httpPool := pool.NewHTTPPool(slog.Default())
-	unifiedPool := pool.NewUnifiedPool(stdioPool, httpPool, slog.Default())
+	ssePool := pool.NewSSEPool(slog.Default())
+	unifiedPool := pool.NewUnifiedPool(stdioPool, httpPool, ssePool, slog.Default())
 
 	startedCount := 0
 	for _, srv := range cfg.Servers {
@@ -364,12 +365,19 @@ func runServerRun(cmd *cobra.Command, args []string) error {
 				startedCount++
 				slog.Info("stdio server started", "name", srv.Name)
 			}
-		case registry.TransportHTTP, registry.TransportSSE:
+		case registry.TransportHTTP:
 			if err := httpPool.StartServer(ctx, srv); err != nil {
 				slog.Warn("failed to start HTTP server", "name", srv.Name, "error", err)
 			} else {
 				startedCount++
 				slog.Info("HTTP server started", "name", srv.Name)
+			}
+		case registry.TransportSSE:
+			if err := ssePool.StartServer(ctx, srv); err != nil {
+				slog.Warn("failed to start SSE server", "name", srv.Name, "error", err)
+			} else {
+				startedCount++
+				slog.Info("SSE server started", "name", srv.Name)
 			}
 		}
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -347,6 +347,8 @@ func runServerRun(cmd *cobra.Command, args []string) error {
 	}
 
 	stdioPool := pool.NewStdioPool(5, 5*time.Minute, slog.Default())
+	httpPool := pool.NewHTTPPool(slog.Default())
+	unifiedPool := pool.NewUnifiedPool(stdioPool, httpPool, slog.Default())
 
 	startedCount := 0
 	for _, srv := range cfg.Servers {
@@ -354,15 +356,21 @@ func runServerRun(cmd *cobra.Command, args []string) error {
 			slog.Debug("server disabled, skipping", "name", srv.Name)
 			continue
 		}
-		if srv.Transport != registry.TransportStdio {
-			slog.Debug("server not stdio transport, skipping", "name", srv.Name, "transport", srv.Transport)
-			continue
-		}
-		if err := stdioPool.StartServer(ctx, srv); err != nil {
-			slog.Warn("failed to start server", "name", srv.Name, "error", err)
-		} else {
-			startedCount++
-			slog.Info("server started", "name", srv.Name)
+		switch srv.Transport {
+		case registry.TransportStdio:
+			if err := stdioPool.StartServer(ctx, srv); err != nil {
+				slog.Warn("failed to start stdio server", "name", srv.Name, "error", err)
+			} else {
+				startedCount++
+				slog.Info("stdio server started", "name", srv.Name)
+			}
+		case registry.TransportHTTP, registry.TransportSSE:
+			if err := httpPool.StartServer(ctx, srv); err != nil {
+				slog.Warn("failed to start HTTP server", "name", srv.Name, "error", err)
+			} else {
+				startedCount++
+				slog.Info("HTTP server started", "name", srv.Name)
+			}
 		}
 	}
 
@@ -397,14 +405,15 @@ func runServerRun(cmd *cobra.Command, args []string) error {
 			statusStore.RemoveFile()
 		}
 		stdioPool.Close()
+		httpPool.Close()
 		os.Exit(0)
 	}()
 
 	if statusStore != nil {
-		go updateStdioServerStatus(statusStore, stdioPool)
+		go updateServerStatus(statusStore, unifiedPool, stdioPool)
 	}
 
-	handler := mcp.NewHandlerWithToolStore(stdioPool, slog.Default(), cache)
+	handler := mcp.NewHandlerWithToolStore(unifiedPool, slog.Default(), cache)
 
 	return handleStdio(ctx, handler, stdioPool, statusStore)
 }
@@ -445,21 +454,26 @@ func updateStdioServerStatusOnce(statusStore *statusfile.FileStatusStore, stdioP
 	statusStore.UpdateServers(statuses)
 }
 
-func updateStdioServerStatus(statusStore *statusfile.FileStatusStore, stdioPool *pool.StdioPool) {
+func updateServerStatus(statusStore *statusfile.FileStatusStore, unifiedPool pool.ServerSource, stdioPool *pool.StdioPool) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
 	for range ticker.C {
-		if statusStore == nil || stdioPool == nil {
+		if statusStore == nil || unifiedPool == nil {
 			continue
 		}
 
-		servers := stdioPool.ListServers()
+		servers := unifiedPool.ListServers()
 		statuses := make([]statusfile.ServerStatus, 0, len(servers))
 
 		for _, name := range servers {
-			state, _ := stdioPool.GetServerState(name)
-			stats, _ := stdioPool.GetServerStats(name)
+			state, _ := unifiedPool.GetServerState(name)
+
+			stats := pool.ServerStats{}
+			stdioStats, err := stdioPool.GetServerStats(name)
+			if err == nil {
+				stats = stdioStats
+			}
 
 			status := statusfile.ServerStatus{
 				Name:         name,

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -135,7 +135,8 @@ func getRealStatusList() proxy.ServerStatusList {
 
 	stdioPool := pool.NewStdioPool(5, 5*time.Minute, slog.Default())
 	httpPool := pool.NewHTTPPool(slog.Default())
-	unifiedPool := pool.NewUnifiedPool(stdioPool, httpPool, slog.Default())
+	ssePool := pool.NewSSEPool(slog.Default())
+	unifiedPool := pool.NewUnifiedPool(stdioPool, httpPool, ssePool, slog.Default())
 
 	for _, srv := range cfg.Servers {
 		if srv.Enabled != nil && !*srv.Enabled {
@@ -146,9 +147,13 @@ func getRealStatusList() proxy.ServerStatusList {
 			if err := stdioPool.StartServer(ctx, srv); err != nil {
 				slog.Warn("failed to start server for status check", "name", srv.Name, "error", err)
 			}
-		case registry.TransportHTTP, registry.TransportSSE:
+		case registry.TransportHTTP:
 			if err := httpPool.StartServer(ctx, srv); err != nil {
 				slog.Warn("failed to start HTTP server for status check", "name", srv.Name, "error", err)
+			}
+		case registry.TransportSSE:
+			if err := ssePool.StartServer(ctx, srv); err != nil {
+				slog.Warn("failed to start SSE server for status check", "name", srv.Name, "error", err)
 			}
 		}
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -134,7 +134,7 @@ func getRealStatusList() proxy.ServerStatusList {
 	}
 
 	stdioPool := pool.NewStdioPool(5, 5*time.Minute, slog.Default())
-	httpPool := pool.NewHTTPPool(slog.Default())
+	httpPool := pool.NewHTTPClientPool(slog.Default())
 	ssePool := pool.NewSSEPool(slog.Default())
 	unifiedPool := pool.NewUnifiedPool(stdioPool, httpPool, ssePool, slog.Default())
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -134,25 +134,36 @@ func getRealStatusList() proxy.ServerStatusList {
 	}
 
 	stdioPool := pool.NewStdioPool(5, 5*time.Minute, slog.Default())
+	httpPool := pool.NewHTTPPool(slog.Default())
+	unifiedPool := pool.NewUnifiedPool(stdioPool, httpPool, slog.Default())
 
 	for _, srv := range cfg.Servers {
 		if srv.Enabled != nil && !*srv.Enabled {
 			continue
 		}
-		if srv.Transport != registry.TransportStdio {
-			continue
-		}
-		if err := stdioPool.StartServer(ctx, srv); err != nil {
-			slog.Warn("failed to start server for status check", "name", srv.Name, "error", err)
+		switch srv.Transport {
+		case registry.TransportStdio:
+			if err := stdioPool.StartServer(ctx, srv); err != nil {
+				slog.Warn("failed to start server for status check", "name", srv.Name, "error", err)
+			}
+		case registry.TransportHTTP, registry.TransportSSE:
+			if err := httpPool.StartServer(ctx, srv); err != nil {
+				slog.Warn("failed to start HTTP server for status check", "name", srv.Name, "error", err)
+			}
 		}
 	}
 
-	servers := stdioPool.ListServers()
+	servers := unifiedPool.ListServers()
 	statusList := make([]proxy.ServerStatus, 0, len(servers))
 
 	for _, serverName := range servers {
-		state, _ := stdioPool.GetServerState(serverName)
-		stats, _ := stdioPool.GetServerStats(serverName)
+		state, _ := unifiedPool.GetServerState(serverName)
+
+		stats := pool.ServerStats{}
+		stdioStats, err := stdioPool.GetServerStats(serverName)
+		if err == nil {
+			stats = stdioStats
+		}
 
 		status := proxy.ServerStatus{
 			Name:            serverName,
@@ -188,6 +199,7 @@ func getRealStatusList() proxy.ServerStatusList {
 	}
 
 	stdioPool.Close()
+	httpPool.Close()
 
 	return proxy.ServerStatusList{
 		Timestamp: time.Now(),

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,6 +15,79 @@ leanproxy-mcp server add filesystem "npx -y @modelcontextprotocol/server-filesys
 # Or manually edit ~/.config/leanproxy_servers.yaml
 ```
 
+#### Server Configuration Format
+
+The server configuration file supports three transport types: `stdio`, `http`, and `sse`.
+
+```yaml
+version: "1.0"
+servers:
+  - name: <server-name>
+    enabled: true
+    transport: <stdio|http|sse>
+    timeout: 30s
+    connect_timeout: 10s
+    # Transport-specific configuration
+    stdio:
+      command: <command>
+      args: [<args>]
+      env: [<env-vars>]
+      cwd: <working-directory>
+    http:
+      url: <http-url>
+      headers:
+        <header-key>: <header-value>
+    sse:
+      url: <sse-url>
+```
+
+##### Stdio Transport Example
+
+```yaml
+servers:
+  - name: filesystem
+    enabled: true
+    transport: stdio
+    stdio:
+      command: npx
+      args:
+        - -y
+        - @modelcontextprotocol/server-filesystem
+        - ./"
+      cwd: .
+    timeout: 30s
+```
+
+##### HTTP Transport Example (with Authentication)
+
+```yaml
+servers:
+  - name: github
+    enabled: true
+    transport: http
+    http:
+      url: https://api.githubcopilot.com/mcp
+      headers:
+        Authorization: Bearer ghp_yourPersonalAccessToken
+        Content-Type: application/json
+    timeout: 30s
+    connect_timeout: 10s
+```
+
+##### SSE Transport Example
+
+```yaml
+servers:
+  - name: my-sse-server
+    enabled: true
+    transport: sse
+    sse:
+      url: https://your-server.com/mcp/sse
+    timeout: 30s
+```
+
+> **Tip**: For GitHub Copilot, use the `/mcp` endpoint (not `/mcp/sse`) with HTTP transport and your PAT in the Authorization header.
+
 ### 2. Run LeanProxy-MCP as an MCP Server
 
 Start leanproxy-mcp in stdio mode to proxy all configured MCP servers:

--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -26,12 +26,12 @@ type ToolCache struct {
 }
 
 type Handler struct {
-	pool       *pool.StdioPool
-	manifest   *AggregatedManifest
-	logger     *slog.Logger
-	timeout    time.Duration
-	toolCache  *ToolCache
-	toolStore  toolstore.Cache
+	pool      pool.ServerSource
+	logger    *slog.Logger
+	timeout   time.Duration
+	toolCache *ToolCache
+	toolStore toolstore.Cache
+	manifest  *AggregatedManifest
 }
 
 type AggregatedManifest struct {
@@ -40,7 +40,7 @@ type AggregatedManifest struct {
 	Prompts   []Prompt
 }
 
-func NewHandler(p *pool.StdioPool, logger *slog.Logger) *Handler {
+func NewHandler(p pool.ServerSource, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -54,7 +54,7 @@ func NewHandler(p *pool.StdioPool, logger *slog.Logger) *Handler {
 	}
 }
 
-func NewHandlerWithToolStore(p *pool.StdioPool, logger *slog.Logger, store toolstore.Cache) *Handler {
+func NewHandlerWithToolStore(p pool.ServerSource, logger *slog.Logger, store toolstore.Cache) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -309,7 +309,7 @@ func (h *Handler) handleSearchTools(ctx context.Context, req *Request, params To
 	h.toolCache.mu.RUnlock()
 
 	if !cachePopulated {
-		h.populateToolCache(ctx)
+		h.PopulateToolCache(ctx)
 	}
 
 	results := h.searchToolCache(query, maxDescChars)
@@ -344,7 +344,7 @@ func (h *Handler) handleSearchTools(ctx context.Context, req *Request, params To
 	}, nil
 }
 
-func (h *Handler) populateToolCache(ctx context.Context) {
+func (h *Handler) PopulateToolCache(ctx context.Context) {
 	h.logger.Info("populating tool cache from backend servers")
 
 	if h.toolStore != nil {
@@ -401,9 +401,9 @@ func (h *Handler) refreshToolCacheFromServers(ctx context.Context) {
 			time.Sleep(500 * time.Millisecond)
 		}
 
-		if err := h.initializeServer(ctx, serverName); err != nil {
-			h.logger.Warn("failed to initialize server for cache", "name", serverName, "error", err)
-			continue
+		initErr := h.initializeServer(ctx, serverName)
+		if initErr != nil {
+			h.logger.Debug("failed to initialize server, will try without initialization", "name", serverName, "error", initErr)
 		}
 
 		h.logger.Debug("requesting tools/list for cache", "name", serverName)

--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
@@ -400,14 +399,6 @@ func (p *UnifiedPool) SendRequestToServer(ctx context.Context, name string, meth
 		return p.ssePool.SendRequestToServer(ctx, name, method, params, timeout)
 	}
 	return nil, fmt.Errorf("server %s not found in any pool", name)
-}
-
-func isNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "not found")
 }
 
 func (p *UnifiedPool) RestartServer(ctx context.Context, name string) error {

--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -271,7 +271,8 @@ func (p *HTTPClientPool) SendRequestToServerWithID(ctx context.Context, name str
 		if err != nil {
 			return nil, err
 		}
-		resultBytes, _ := json.Marshal(tools)
+		result := mcp.ListToolsResult{Tools: tools}
+		resultBytes, _ := json.Marshal(result)
 		return &Response{
 			Result: resultBytes,
 			ID:     id,

--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -1,157 +1,167 @@
 package pool
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
 	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
 )
 
-type HTTPConfig struct {
-	URL     string
-	Headers map[string]string
+type HTTPClientServer struct {
+	name     string
+	config   *migrate.ServerConfig
+	mcpClient *client.Client
+	state    ServerState
+	mu       sync.RWMutex
+	logger   *slog.Logger
+	initOnce sync.Once
+	initErr  error
 }
 
-type HTTPServer struct {
-	name    string
-	config  *migrate.ServerConfig
-	httpCfg HTTPConfig
-	client  *http.Client
-	state   ServerState
-	mu      sync.RWMutex
-	logger  *slog.Logger
-}
-
-func NewHTTPServer(name string, config *migrate.ServerConfig, logger *slog.Logger) *HTTPServer {
-	httpCfg := HTTPConfig{
-		URL:     config.HTTP.URL,
-		Headers: config.HTTP.Headers,
+func NewHTTPClientServer(name string, config *migrate.ServerConfig, logger *slog.Logger) *HTTPClientServer {
+	if logger == nil {
+		logger = slog.Default()
 	}
 
-	timeout := 30 * time.Second
-	if config.TimeoutValue > 0 {
-		timeout = config.TimeoutValue
-	}
-
-	return &HTTPServer{
-		name:    name,
-		config:  config,
-		httpCfg: httpCfg,
-		client: &http.Client{
-			Timeout: timeout,
-		},
-		state:  StateRunning,
+	return &HTTPClientServer{
+		name:   name,
+		config: config,
+		state:  StateStarting,
 		logger: logger,
 	}
 }
 
-func (s *HTTPServer) getState() ServerState {
+func (s *HTTPClientServer) getState() ServerState {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.state
 }
 
-func (s *HTTPServer) setState(state ServerState) {
+func (s *HTTPClientServer) setState(state ServerState) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.state = state
 }
 
-func (s *HTTPServer) SendRequest(ctx context.Context, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
-	var reqParams interface{}
-	if len(params) > 0 {
-		if err := json.Unmarshal(params, &reqParams); err != nil {
-			reqParams = params
+func (s *HTTPClientServer) Initialize(ctx context.Context) error {
+	s.initOnce.Do(func() {
+		baseURL := s.config.HTTP.URL
+		s.logger.Debug("http_pool: creating StreamableHTTP client", "server", s.name, "url", baseURL)
+
+		c, err := client.NewStreamableHttpClient(baseURL)
+		if err != nil {
+			s.initErr = fmt.Errorf("http_pool: create client: %w", err)
+			s.setState(StateError)
+			return
 		}
-	} else {
-		reqParams = map[string]interface{}{}
-	}
 
-	reqBody := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"method":  method,
-		"params":  reqParams,
-		"id":      1,
-	}
+		// For servers that need headers, we set them via a header function
+		// Note: mcp-go handles auth internally for most cases
 
-	bodyBytes, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("http_pool: marshal request: %w", err)
-	}
+		s.logger.Debug("http_pool: initializing StreamableHTTP client", "server", s.name)
+		startCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "POST", s.httpCfg.URL, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("http_pool: create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json, text/event-stream")
-	for k, v := range s.httpCfg.Headers {
-		req.Header.Set(k, v)
-	}
-
-	s.logger.Debug("http_pool: sending request", "server", s.name, "method", method, "url", s.httpCfg.URL)
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		s.setState(StateError)
-		return nil, fmt.Errorf("http_pool: do request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		s.setState(StateError)
-		respBody, _ := io.ReadAll(resp.Body)
-		errMsg := string(respBody)
-		if errMsg == "" {
-			errMsg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		if err := c.Start(startCtx); err != nil {
+			s.initErr = fmt.Errorf("http_pool: start: %w", err)
+			s.setState(StateError)
+			c.Close()
+			return
 		}
-		return nil, fmt.Errorf("http_pool: server returned %s", errMsg)
-	}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("http_pool: read response: %w", err)
-	}
+		initCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
 
-	var rpcResp Response
-	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
-		return nil, fmt.Errorf("http_pool: unmarshal response: %w", err)
-	}
+		_, err = c.Initialize(initCtx, mcp.InitializeRequest{
+			Params: mcp.InitializeParams{
+				ProtocolVersion: "2024-11-05",
+				Capabilities:    mcp.ClientCapabilities{},
+				ClientInfo: mcp.Implementation{
+					Name:    "leanproxy-mcp",
+					Version: "1.0.0",
+				},
+			},
+		})
+		if err != nil {
+			s.initErr = fmt.Errorf("http_pool: initialize: %w", err)
+			s.setState(StateError)
+			c.Close()
+			return
+		}
 
-	s.setState(StateRunning)
-	return &rpcResp, nil
+		s.mcpClient = c
+		s.setState(StateRunning)
+		s.logger.Info("http_pool: server initialized", "server", s.name)
+	})
+
+	return s.initErr
 }
 
-type HTTPTransportType string
+func (s *HTTPClientServer) Close() error {
+	if s.mcpClient != nil {
+		s.mcpClient.Close()
+	}
+	s.setState(StateStopped)
+	return nil
+}
 
-const HTTPTransport HTTPTransportType = "http"
+func (s *HTTPClientServer) ListTools(ctx context.Context) ([]mcp.Tool, error) {
+	if s.mcpClient == nil {
+		return nil, fmt.Errorf("http_pool: client not initialized")
+	}
 
-type HTTPPool struct {
-	servers map[string]*HTTPServer
+	resp, err := s.mcpClient.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("http_pool: list tools: %w", err)
+	}
+
+	return resp.Tools, nil
+}
+
+func (s *HTTPClientServer) CallTool(ctx context.Context, name string, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	if s.mcpClient == nil {
+		return nil, fmt.Errorf("http_pool: client not initialized")
+	}
+
+	return s.mcpClient.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      name,
+			Arguments: args,
+		},
+	})
+}
+
+type HTTPClientPool struct {
+	servers map[string]*HTTPClientServer
 	mu      sync.RWMutex
 	logger  *slog.Logger
+	ctx     context.Context
+	cancel  context.CancelFunc
 }
 
-func NewHTTPPool(logger *slog.Logger) *HTTPPool {
+func NewHTTPClientPool(logger *slog.Logger) *HTTPClientPool {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &HTTPPool{
-		servers: make(map[string]*HTTPServer),
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &HTTPClientPool{
+		servers: make(map[string]*HTTPClientServer),
 		logger:  logger,
+		ctx:     ctx,
+		cancel:  cancel,
 	}
 }
 
-func (p *HTTPPool) StartServer(ctx context.Context, config *migrate.ServerConfig) error {
+func (p *HTTPClientPool) StartServer(ctx context.Context, config *migrate.ServerConfig) error {
 	if config.HTTP == nil || config.HTTP.URL == "" {
 		return fmt.Errorf("http_pool: HTTP config is required")
 	}
@@ -164,14 +174,23 @@ func (p *HTTPPool) StartServer(ctx context.Context, config *migrate.ServerConfig
 		return nil
 	}
 
-	server := NewHTTPServer(config.Name, config, p.logger)
+	server := NewHTTPClientServer(config.Name, config, p.logger)
 	p.servers[config.Name] = server
 
-	p.logger.Info("http_pool: server started", "name", config.Name, "url", config.HTTP.URL)
+	p.logger.Info("http_pool: server created", "name", config.Name, "url", config.HTTP.URL)
+
+	go func() {
+		initCtx, cancel := context.WithTimeout(p.ctx, 30*time.Second)
+		defer cancel()
+		if err := server.Initialize(initCtx); err != nil {
+			p.logger.Warn("http_pool: failed to initialize server", "name", config.Name, "error", err)
+		}
+	}()
+
 	return nil
 }
 
-func (p *HTTPPool) ListServers() []string {
+func (p *HTTPClientPool) ListServers() []string {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -182,7 +201,7 @@ func (p *HTTPPool) ListServers() []string {
 	return names
 }
 
-func (p *HTTPPool) GetServerState(name string) (ServerState, error) {
+func (p *HTTPClientPool) GetServerState(name string) (ServerState, error) {
 	p.mu.RLock()
 	server, exists := p.servers[name]
 	p.mu.RUnlock()
@@ -194,7 +213,7 @@ func (p *HTTPPool) GetServerState(name string) (ServerState, error) {
 	return server.getState(), nil
 }
 
-func (p *HTTPPool) SendRequest(ctx context.Context, serverName string, req *proxy.JSONRPCRequest, timeout time.Duration) (*proxy.JSONRPCResponse, error) {
+func (p *HTTPClientPool) SendRequest(ctx context.Context, serverName string, req *proxy.JSONRPCRequest, timeout time.Duration) (*proxy.JSONRPCResponse, error) {
 	p.mu.RLock()
 	server, exists := p.servers[serverName]
 	p.mu.RUnlock()
@@ -203,23 +222,29 @@ func (p *HTTPPool) SendRequest(ctx context.Context, serverName string, req *prox
 		return nil, fmt.Errorf("http_pool: server %s not found", serverName)
 	}
 
-	resp, err := server.SendRequest(ctx, req.Method, req.Params, timeout)
+	toolArgs := make(map[string]interface{})
+	if req.Params != nil {
+		_ = json.Unmarshal(req.Params, &toolArgs)
+	}
+
+	result, err := server.CallTool(ctx, req.Method, toolArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.Error != nil {
-		return nil, resp.Error
-	}
-
+	resultBytes, _ := json.Marshal(result)
 	return &proxy.JSONRPCResponse{
 		JSONRPC: "2.0",
-		Result:  resp.Result,
-		ID:      resp.ID,
+		Result:  resultBytes,
+		ID:      req.ID,
 	}, nil
 }
 
-func (p *HTTPPool) SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
+func (p *HTTPClientPool) SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
+	return p.SendRequestToServerWithID(ctx, name, method, params, timeout, 1)
+}
+
+func (p *HTTPClientPool) SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error) {
 	p.mu.RLock()
 	server, exists := p.servers[name]
 	p.mu.RUnlock()
@@ -228,22 +253,36 @@ func (p *HTTPPool) SendRequestToServer(ctx context.Context, name string, method 
 		return nil, fmt.Errorf("http_pool: server %s not found", name)
 	}
 
-	return server.SendRequest(ctx, method, params, timeout)
-}
-
-func (p *HTTPPool) SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error) {
-	p.mu.RLock()
-	server, exists := p.servers[name]
-	p.mu.RUnlock()
-
-	if !exists {
-		return nil, fmt.Errorf("http_pool: server %s not found", name)
+	if server.mcpClient == nil {
+		initCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		if err := server.Initialize(initCtx); err != nil {
+			return nil, err
+		}
 	}
 
-	return server.SendRequest(ctx, method, params, timeout)
+	toolArgs := make(map[string]interface{})
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &toolArgs)
+	}
+
+	result, err := server.CallTool(ctx, method, toolArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	resultBytes, _ := json.Marshal(result)
+	return &Response{
+		Result: resultBytes,
+		ID:     id,
+	}, nil
 }
 
-func (p *HTTPPool) RestartServer(ctx context.Context, name string) error {
+func (p *HTTPClientPool) SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error {
+	return nil
+}
+
+func (p *HTTPClientPool) RestartServer(ctx context.Context, name string) error {
 	p.mu.RLock()
 	server, exists := p.servers[name]
 	p.mu.RUnlock()
@@ -257,67 +296,44 @@ func (p *HTTPPool) RestartServer(ctx context.Context, name string) error {
 	return nil
 }
 
-func (p *HTTPPool) SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error {
-	p.mu.RLock()
-	server, exists := p.servers[name]
-	p.mu.RUnlock()
+func (p *HTTPClientPool) Close() error {
+	p.cancel()
 
-	if !exists {
-		return fmt.Errorf("http_pool: server %s not found", name)
-	}
-
-	paramsBytes, _ := json.Marshal(params)
-	_, err := server.SendRequest(ctx, method, paramsBytes, 10*time.Second)
-	return err
-}
-
-func (p *HTTPPool) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	for name, server := range p.servers {
-		server.setState(StateStopped)
-		p.logger.Debug("http_pool: server stopped", "name", name)
+	for _, server := range p.servers {
+		server.Close()
 	}
-	p.servers = make(map[string]*HTTPServer)
+	p.servers = make(map[string]*HTTPClientServer)
 	return nil
 }
 
-func (p *HTTPPool) ServerCount() int {
+func (p *HTTPClientPool) ServerCount() int {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return len(p.servers)
 }
 
-type ServerSource interface {
-	ListServers() []string
-	GetServerState(name string) (ServerState, error)
-	SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error)
-	SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error)
-	SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error
-	RestartServer(ctx context.Context, name string) error
-	Close() error
+func (p *HTTPClientPool) HasServer(name string) bool {
+	p.mu.RLock()
+	_, exists := p.servers[name]
+	p.mu.RUnlock()
+	return exists
 }
-
-var _ ServerSource = (*StdioPool)(nil)
-var _ ServerSource = (*HTTPPool)(nil)
-var _ ServerSource = (*SSEPool)(nil)
 
 type UnifiedPool struct {
 	stdioPool *StdioPool
-	httpPool  *HTTPPool
+	httpPool  *HTTPClientPool
 	ssePool   *SSEPool
 	logger    *slog.Logger
 }
 
-func NewUnifiedPool(stdioPool *StdioPool, httpPool *HTTPPool, ssePool *SSEPool, logger *slog.Logger) *UnifiedPool {
-	if logger == nil {
-		logger = slog.Default()
-	}
+func NewUnifiedPool(stdio *StdioPool, http *HTTPClientPool, sse *SSEPool, logger *slog.Logger) *UnifiedPool {
 	return &UnifiedPool{
-		stdioPool: stdioPool,
-		httpPool:  httpPool,
-		ssePool:   ssePool,
+		stdioPool: stdio,
+		httpPool:  http,
+		ssePool:   sse,
 		logger:    logger,
 	}
 }
@@ -348,18 +364,32 @@ func (p *UnifiedPool) GetServerState(name string) (ServerState, error) {
 }
 
 func (p *UnifiedPool) SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
-	resp, err := p.stdioPool.SendRequestToServer(ctx, name, method, params, timeout)
-	if err == nil {
-		return resp, nil
+	if p.stdioPool.HasServer(name) {
+		resp, err := p.stdioPool.SendRequestToServer(ctx, name, method, params, timeout)
+		if err == nil {
+			return resp, nil
+		}
+		return nil, err
 	}
-	resp, err = p.httpPool.SendRequestToServer(ctx, name, method, params, timeout)
-	if err == nil {
-		return resp, nil
+	if p.httpPool.HasServer(name) {
+		resp, err := p.httpPool.SendRequestToServer(ctx, name, method, params, timeout)
+		if err == nil {
+			return resp, nil
+		}
+		return nil, err
 	}
-	if p.ssePool != nil {
+	if p.ssePool != nil && p.ssePool.HasServer(name) {
 		return p.ssePool.SendRequestToServer(ctx, name, method, params, timeout)
 	}
-	return nil, fmt.Errorf("server %s not found", name)
+	return nil, fmt.Errorf("server %s not found in any pool", name)
+}
+
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "not found")
 }
 
 func (p *UnifiedPool) RestartServer(ctx context.Context, name string) error {
@@ -378,18 +408,24 @@ func (p *UnifiedPool) RestartServer(ctx context.Context, name string) error {
 }
 
 func (p *UnifiedPool) SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error) {
-	resp, err := p.stdioPool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
-	if err == nil {
-		return resp, nil
+	if p.stdioPool.HasServer(name) {
+		resp, err := p.stdioPool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
+		if err == nil {
+			return resp, nil
+		}
+		return nil, err
 	}
-	resp, err = p.httpPool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
-	if err == nil {
-		return resp, nil
+	if p.httpPool.HasServer(name) {
+		resp, err := p.httpPool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
+		if err == nil {
+			return resp, nil
+		}
+		return nil, err
 	}
-	if p.ssePool != nil {
+	if p.ssePool != nil && p.ssePool.HasServer(name) {
 		return p.ssePool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
 	}
-	return nil, fmt.Errorf("server %s not found", name)
+	return nil, fmt.Errorf("server %s not found in any pool", name)
 }
 
 func (p *UnifiedPool) SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error {
@@ -430,5 +466,3 @@ func (p *UnifiedPool) SendRequest(ctx context.Context, serverName string, req *p
 	}
 	return nil, fmt.Errorf("server %s not found", serverName)
 }
-
-var _ ServerSource = (*UnifiedPool)(nil)

--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
 	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
@@ -56,15 +57,19 @@ func (s *HTTPClientServer) Initialize(ctx context.Context) error {
 		baseURL := s.config.HTTP.URL
 		s.logger.Debug("http_pool: creating StreamableHTTP client", "server", s.name, "url", baseURL)
 
-		c, err := client.NewStreamableHttpClient(baseURL)
+		headers := make(map[string]string)
+		if s.config.HTTP != nil && s.config.HTTP.Headers != nil {
+			for k, v := range s.config.HTTP.Headers {
+				headers[k] = v
+			}
+		}
+
+		c, err := client.NewStreamableHttpClient(baseURL, transport.WithHTTPHeaders(headers))
 		if err != nil {
 			s.initErr = fmt.Errorf("http_pool: create client: %w", err)
 			s.setState(StateError)
 			return
 		}
-
-		// For servers that need headers, we set them via a header function
-		// Note: mcp-go handles auth internally for most cases
 
 		s.logger.Debug("http_pool: initializing StreamableHTTP client", "server", s.name)
 		startCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -259,6 +264,18 @@ func (p *HTTPClientPool) SendRequestToServerWithID(ctx context.Context, name str
 		if err := server.Initialize(initCtx); err != nil {
 			return nil, err
 		}
+	}
+
+	if method == "tools/list" {
+		tools, err := server.ListTools(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resultBytes, _ := json.Marshal(tools)
+		return &Response{
+			Result: resultBytes,
+			ID:     id,
+		}, nil
 	}
 
 	toolArgs := make(map[string]interface{})

--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -67,7 +67,7 @@ func (s *HTTPServer) setState(state ServerState) {
 
 func (s *HTTPServer) SendRequest(ctx context.Context, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
 	var reqParams interface{}
-	if params != nil && len(params) > 0 {
+	if len(params) > 0 {
 		if err := json.Unmarshal(params, &reqParams); err != nil {
 			reqParams = params
 		}
@@ -301,20 +301,23 @@ type ServerSource interface {
 
 var _ ServerSource = (*StdioPool)(nil)
 var _ ServerSource = (*HTTPPool)(nil)
+var _ ServerSource = (*SSEPool)(nil)
 
 type UnifiedPool struct {
 	stdioPool *StdioPool
 	httpPool  *HTTPPool
+	ssePool   *SSEPool
 	logger    *slog.Logger
 }
 
-func NewUnifiedPool(stdioPool *StdioPool, httpPool *HTTPPool, logger *slog.Logger) *UnifiedPool {
+func NewUnifiedPool(stdioPool *StdioPool, httpPool *HTTPPool, ssePool *SSEPool, logger *slog.Logger) *UnifiedPool {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &UnifiedPool{
 		stdioPool: stdioPool,
 		httpPool:  httpPool,
+		ssePool:   ssePool,
 		logger:    logger,
 	}
 }
@@ -323,6 +326,9 @@ func (p *UnifiedPool) ListServers() []string {
 	var servers []string
 	servers = append(servers, p.stdioPool.ListServers()...)
 	servers = append(servers, p.httpPool.ListServers()...)
+	if p.ssePool != nil {
+		servers = append(servers, p.ssePool.ListServers()...)
+	}
 	return servers
 }
 
@@ -331,7 +337,14 @@ func (p *UnifiedPool) GetServerState(name string) (ServerState, error) {
 	if err == nil {
 		return state, nil
 	}
-	return p.httpPool.GetServerState(name)
+	state, err = p.httpPool.GetServerState(name)
+	if err == nil {
+		return state, nil
+	}
+	if p.ssePool != nil {
+		return p.ssePool.GetServerState(name)
+	}
+	return "", fmt.Errorf("server %s not found in any pool", name)
 }
 
 func (p *UnifiedPool) SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
@@ -339,7 +352,14 @@ func (p *UnifiedPool) SendRequestToServer(ctx context.Context, name string, meth
 	if err == nil {
 		return resp, nil
 	}
-	return p.httpPool.SendRequestToServer(ctx, name, method, params, timeout)
+	resp, err = p.httpPool.SendRequestToServer(ctx, name, method, params, timeout)
+	if err == nil {
+		return resp, nil
+	}
+	if p.ssePool != nil {
+		return p.ssePool.SendRequestToServer(ctx, name, method, params, timeout)
+	}
+	return nil, fmt.Errorf("server %s not found", name)
 }
 
 func (p *UnifiedPool) RestartServer(ctx context.Context, name string) error {
@@ -347,7 +367,14 @@ func (p *UnifiedPool) RestartServer(ctx context.Context, name string) error {
 	if err == nil {
 		return nil
 	}
-	return p.httpPool.RestartServer(ctx, name)
+	err = p.httpPool.RestartServer(ctx, name)
+	if err == nil {
+		return nil
+	}
+	if p.ssePool != nil {
+		return p.ssePool.RestartServer(ctx, name)
+	}
+	return fmt.Errorf("server %s not found", name)
 }
 
 func (p *UnifiedPool) SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error) {
@@ -355,7 +382,14 @@ func (p *UnifiedPool) SendRequestToServerWithID(ctx context.Context, name string
 	if err == nil {
 		return resp, nil
 	}
-	return p.httpPool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
+	resp, err = p.httpPool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
+	if err == nil {
+		return resp, nil
+	}
+	if p.ssePool != nil {
+		return p.ssePool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
+	}
+	return nil, fmt.Errorf("server %s not found", name)
 }
 
 func (p *UnifiedPool) SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error {
@@ -363,12 +397,22 @@ func (p *UnifiedPool) SendServerNotification(ctx context.Context, name string, m
 	if err == nil {
 		return nil
 	}
-	return p.httpPool.SendServerNotification(ctx, name, method, params)
+	err = p.httpPool.SendServerNotification(ctx, name, method, params)
+	if err == nil {
+		return nil
+	}
+	if p.ssePool != nil {
+		return p.ssePool.SendServerNotification(ctx, name, method, params)
+	}
+	return fmt.Errorf("server %s not found", name)
 }
 
 func (p *UnifiedPool) Close() error {
 	p.stdioPool.Close()
 	p.httpPool.Close()
+	if p.ssePool != nil {
+		p.ssePool.Close()
+	}
 	return nil
 }
 
@@ -377,7 +421,14 @@ func (p *UnifiedPool) SendRequest(ctx context.Context, serverName string, req *p
 	if err == nil {
 		return resp, nil
 	}
-	return p.httpPool.SendRequest(ctx, serverName, req, timeout)
+	resp, err = p.httpPool.SendRequest(ctx, serverName, req, timeout)
+	if err == nil {
+		return resp, nil
+	}
+	if p.ssePool != nil {
+		return p.ssePool.SendRequest(ctx, serverName, req, timeout)
+	}
+	return nil, fmt.Errorf("server %s not found", serverName)
 }
 
 var _ ServerSource = (*UnifiedPool)(nil)

--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -1,0 +1,383 @@
+package pool
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
+	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
+)
+
+type HTTPConfig struct {
+	URL     string
+	Headers map[string]string
+}
+
+type HTTPServer struct {
+	name    string
+	config  *migrate.ServerConfig
+	httpCfg HTTPConfig
+	client  *http.Client
+	state   ServerState
+	mu      sync.RWMutex
+	logger  *slog.Logger
+}
+
+func NewHTTPServer(name string, config *migrate.ServerConfig, logger *slog.Logger) *HTTPServer {
+	httpCfg := HTTPConfig{
+		URL:     config.HTTP.URL,
+		Headers: config.HTTP.Headers,
+	}
+
+	timeout := 30 * time.Second
+	if config.TimeoutValue > 0 {
+		timeout = config.TimeoutValue
+	}
+
+	return &HTTPServer{
+		name:    name,
+		config:  config,
+		httpCfg: httpCfg,
+		client: &http.Client{
+			Timeout: timeout,
+		},
+		state:  StateRunning,
+		logger: logger,
+	}
+}
+
+func (s *HTTPServer) getState() ServerState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state
+}
+
+func (s *HTTPServer) setState(state ServerState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state = state
+}
+
+func (s *HTTPServer) SendRequest(ctx context.Context, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
+	var reqParams interface{}
+	if params != nil && len(params) > 0 {
+		if err := json.Unmarshal(params, &reqParams); err != nil {
+			reqParams = params
+		}
+	} else {
+		reqParams = map[string]interface{}{}
+	}
+
+	reqBody := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"params":  reqParams,
+		"id":      1,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("http_pool: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", s.httpCfg.URL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("http_pool: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	for k, v := range s.httpCfg.Headers {
+		req.Header.Set(k, v)
+	}
+
+	s.logger.Debug("http_pool: sending request", "server", s.name, "method", method, "url", s.httpCfg.URL)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.setState(StateError)
+		return nil, fmt.Errorf("http_pool: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		s.setState(StateError)
+		respBody, _ := io.ReadAll(resp.Body)
+		errMsg := string(respBody)
+		if errMsg == "" {
+			errMsg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("http_pool: server returned %s", errMsg)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("http_pool: read response: %w", err)
+	}
+
+	var rpcResp Response
+	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+		return nil, fmt.Errorf("http_pool: unmarshal response: %w", err)
+	}
+
+	s.setState(StateRunning)
+	return &rpcResp, nil
+}
+
+type HTTPTransportType string
+
+const HTTPTransport HTTPTransportType = "http"
+
+type HTTPPool struct {
+	servers map[string]*HTTPServer
+	mu      sync.RWMutex
+	logger  *slog.Logger
+}
+
+func NewHTTPPool(logger *slog.Logger) *HTTPPool {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &HTTPPool{
+		servers: make(map[string]*HTTPServer),
+		logger:  logger,
+	}
+}
+
+func (p *HTTPPool) StartServer(ctx context.Context, config *migrate.ServerConfig) error {
+	if config.HTTP == nil || config.HTTP.URL == "" {
+		return fmt.Errorf("http_pool: HTTP config is required")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, exists := p.servers[config.Name]; exists {
+		p.logger.Debug("http_pool: server already exists", "name", config.Name)
+		return nil
+	}
+
+	server := NewHTTPServer(config.Name, config, p.logger)
+	p.servers[config.Name] = server
+
+	p.logger.Info("http_pool: server started", "name", config.Name, "url", config.HTTP.URL)
+	return nil
+}
+
+func (p *HTTPPool) ListServers() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	names := make([]string, 0, len(p.servers))
+	for name := range p.servers {
+		names = append(names, name)
+	}
+	return names
+}
+
+func (p *HTTPPool) GetServerState(name string) (ServerState, error) {
+	p.mu.RLock()
+	server, exists := p.servers[name]
+	p.mu.RUnlock()
+
+	if !exists {
+		return "", fmt.Errorf("http_pool: server %s not found", name)
+	}
+
+	return server.getState(), nil
+}
+
+func (p *HTTPPool) SendRequest(ctx context.Context, serverName string, req *proxy.JSONRPCRequest, timeout time.Duration) (*proxy.JSONRPCResponse, error) {
+	p.mu.RLock()
+	server, exists := p.servers[serverName]
+	p.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("http_pool: server %s not found", serverName)
+	}
+
+	resp, err := server.SendRequest(ctx, req.Method, req.Params, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return &proxy.JSONRPCResponse{
+		JSONRPC: "2.0",
+		Result:  resp.Result,
+		ID:      resp.ID,
+	}, nil
+}
+
+func (p *HTTPPool) SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
+	p.mu.RLock()
+	server, exists := p.servers[name]
+	p.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("http_pool: server %s not found", name)
+	}
+
+	return server.SendRequest(ctx, method, params, timeout)
+}
+
+func (p *HTTPPool) SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error) {
+	p.mu.RLock()
+	server, exists := p.servers[name]
+	p.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("http_pool: server %s not found", name)
+	}
+
+	return server.SendRequest(ctx, method, params, timeout)
+}
+
+func (p *HTTPPool) RestartServer(ctx context.Context, name string) error {
+	p.mu.RLock()
+	server, exists := p.servers[name]
+	p.mu.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("http_pool: server %s not found", name)
+	}
+
+	server.setState(StateRunning)
+	p.logger.Info("http_pool: server restarted", "name", name)
+	return nil
+}
+
+func (p *HTTPPool) SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error {
+	p.mu.RLock()
+	server, exists := p.servers[name]
+	p.mu.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("http_pool: server %s not found", name)
+	}
+
+	paramsBytes, _ := json.Marshal(params)
+	_, err := server.SendRequest(ctx, method, paramsBytes, 10*time.Second)
+	return err
+}
+
+func (p *HTTPPool) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for name, server := range p.servers {
+		server.setState(StateStopped)
+		p.logger.Debug("http_pool: server stopped", "name", name)
+	}
+	p.servers = make(map[string]*HTTPServer)
+	return nil
+}
+
+func (p *HTTPPool) ServerCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.servers)
+}
+
+type ServerSource interface {
+	ListServers() []string
+	GetServerState(name string) (ServerState, error)
+	SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error)
+	SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error)
+	SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error
+	RestartServer(ctx context.Context, name string) error
+	Close() error
+}
+
+var _ ServerSource = (*StdioPool)(nil)
+var _ ServerSource = (*HTTPPool)(nil)
+
+type UnifiedPool struct {
+	stdioPool *StdioPool
+	httpPool  *HTTPPool
+	logger    *slog.Logger
+}
+
+func NewUnifiedPool(stdioPool *StdioPool, httpPool *HTTPPool, logger *slog.Logger) *UnifiedPool {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &UnifiedPool{
+		stdioPool: stdioPool,
+		httpPool:  httpPool,
+		logger:    logger,
+	}
+}
+
+func (p *UnifiedPool) ListServers() []string {
+	var servers []string
+	servers = append(servers, p.stdioPool.ListServers()...)
+	servers = append(servers, p.httpPool.ListServers()...)
+	return servers
+}
+
+func (p *UnifiedPool) GetServerState(name string) (ServerState, error) {
+	state, err := p.stdioPool.GetServerState(name)
+	if err == nil {
+		return state, nil
+	}
+	return p.httpPool.GetServerState(name)
+}
+
+func (p *UnifiedPool) SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
+	resp, err := p.stdioPool.SendRequestToServer(ctx, name, method, params, timeout)
+	if err == nil {
+		return resp, nil
+	}
+	return p.httpPool.SendRequestToServer(ctx, name, method, params, timeout)
+}
+
+func (p *UnifiedPool) RestartServer(ctx context.Context, name string) error {
+	err := p.stdioPool.RestartServer(ctx, name)
+	if err == nil {
+		return nil
+	}
+	return p.httpPool.RestartServer(ctx, name)
+}
+
+func (p *UnifiedPool) SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error) {
+	resp, err := p.stdioPool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
+	if err == nil {
+		return resp, nil
+	}
+	return p.httpPool.SendRequestToServerWithID(ctx, name, method, params, timeout, id)
+}
+
+func (p *UnifiedPool) SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error {
+	err := p.stdioPool.SendServerNotification(ctx, name, method, params)
+	if err == nil {
+		return nil
+	}
+	return p.httpPool.SendServerNotification(ctx, name, method, params)
+}
+
+func (p *UnifiedPool) Close() error {
+	p.stdioPool.Close()
+	p.httpPool.Close()
+	return nil
+}
+
+func (p *UnifiedPool) SendRequest(ctx context.Context, serverName string, req *proxy.JSONRPCRequest, timeout time.Duration) (*proxy.JSONRPCResponse, error) {
+	resp, err := p.stdioPool.SendRequest(ctx, serverName, req, timeout)
+	if err == nil {
+		return resp, nil
+	}
+	return p.httpPool.SendRequest(ctx, serverName, req, timeout)
+}
+
+var _ ServerSource = (*UnifiedPool)(nil)

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -14,6 +14,16 @@ import (
 	"github.com/mmornati/leanproxy-mcp/pkg/registry"
 )
 
+type ServerSource interface {
+	SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error)
+	SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error)
+	SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error
+	ListServers() []string
+	GetServerState(name string) (ServerState, error)
+	RestartServer(ctx context.Context, name string) error
+	Close() error
+}
+
 type Request struct {
 	Method     string          `json:"method"`
 	Params     json.RawMessage `json:"params,omitempty"`
@@ -254,6 +264,13 @@ func (p *StdioPool) ServerCount() int {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return len(p.servers)
+}
+
+func (p *StdioPool) HasServer(name string) bool {
+	p.mu.RLock()
+	_, exists := p.servers[name]
+	p.mu.RUnlock()
+	return exists
 }
 
 func (p *StdioPool) GetServerState(name string) (ServerState, error) {

--- a/pkg/pool/sse_pool.go
+++ b/pkg/pool/sse_pool.go
@@ -319,4 +319,9 @@ func (p *SSEPool) ServerCount() int {
 	return len(p.servers)
 }
 
-var _ ServerSource = (*SSEPool)(nil)
+func (p *SSEPool) HasServer(name string) bool {
+	p.mu.RLock()
+	_, exists := p.servers[name]
+	p.mu.RUnlock()
+	return exists
+}

--- a/pkg/pool/sse_pool.go
+++ b/pkg/pool/sse_pool.go
@@ -1,0 +1,322 @@
+package pool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
+	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
+)
+
+type SSEServer struct {
+	name     string
+	config   *migrate.ServerConfig
+	mcpClient *client.Client
+	state    ServerState
+	mu       sync.RWMutex
+	logger   *slog.Logger
+	initOnce sync.Once
+	initErr  error
+}
+
+func NewSSEServer(name string, config *migrate.ServerConfig, logger *slog.Logger) *SSEServer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &SSEServer{
+		name:   name,
+		config: config,
+		state:  StateStarting,
+		logger: logger,
+	}
+}
+
+func (s *SSEServer) getState() ServerState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state
+}
+
+func (s *SSEServer) setState(state ServerState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state = state
+}
+
+func (s *SSEServer) Initialize(ctx context.Context) error {
+	s.initOnce.Do(func() {
+		headers := make(map[string]string)
+		if s.config.HTTP != nil && s.config.HTTP.Headers != nil {
+			for k, v := range s.config.HTTP.Headers {
+				headers[k] = v
+			}
+		}
+
+		baseURL := s.config.HTTP.URL
+		s.logger.Debug("sse_pool: creating SSE client", "server", s.name, "url", baseURL)
+
+		c, err := client.NewSSEMCPClient(baseURL, client.WithHeaders(headers))
+		if err != nil {
+			s.initErr = fmt.Errorf("sse_pool: create client: %w", err)
+			s.setState(StateError)
+			return
+		}
+
+		s.logger.Debug("sse_pool: starting SSE client", "server", s.name)
+		startCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		if err := c.Start(startCtx); err != nil {
+			s.initErr = fmt.Errorf("sse_pool: start: %w", err)
+			s.setState(StateError)
+			c.Close()
+			return
+		}
+
+		s.logger.Debug("sse_pool: initializing SSE client", "server", s.name)
+		initCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		_, err = c.Initialize(initCtx, mcp.InitializeRequest{
+			Params: mcp.InitializeParams{
+				ProtocolVersion: "2024-11-05",
+				Capabilities:    mcp.ClientCapabilities{},
+				ClientInfo: mcp.Implementation{
+					Name:    "leanproxy-mcp",
+					Version: "1.0.0",
+				},
+			},
+		})
+		if err != nil {
+			s.initErr = fmt.Errorf("sse_pool: initialize: %w", err)
+			s.setState(StateError)
+			c.Close()
+			return
+		}
+
+		s.mcpClient = c
+		s.setState(StateRunning)
+		s.logger.Info("sse_pool: server initialized", "server", s.name)
+	})
+
+	return s.initErr
+}
+
+func (s *SSEServer) Close() error {
+	if s.mcpClient != nil {
+		s.mcpClient.Close()
+	}
+	s.setState(StateStopped)
+	return nil
+}
+
+func (s *SSEServer) ListTools(ctx context.Context) ([]mcp.Tool, error) {
+	if s.mcpClient == nil {
+		return nil, fmt.Errorf("sse_pool: client not initialized")
+	}
+
+	resp, err := s.mcpClient.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("sse_pool: list tools: %w", err)
+	}
+
+	return resp.Tools, nil
+}
+
+func (s *SSEServer) CallTool(ctx context.Context, name string, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	if s.mcpClient == nil {
+		return nil, fmt.Errorf("sse_pool: client not initialized")
+	}
+
+	return s.mcpClient.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      name,
+			Arguments: args,
+		},
+	})
+}
+
+type SSEPool struct {
+	servers map[string]*SSEServer
+	mu      sync.RWMutex
+	logger  *slog.Logger
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+func NewSSEPool(logger *slog.Logger) *SSEPool {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &SSEPool{
+		servers: make(map[string]*SSEServer),
+		logger:  logger,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+}
+
+func (p *SSEPool) StartServer(ctx context.Context, config *migrate.ServerConfig) error {
+	if config.HTTP == nil || config.HTTP.URL == "" {
+		return fmt.Errorf("sse_pool: HTTP config is required")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, exists := p.servers[config.Name]; exists {
+		p.logger.Debug("sse_pool: server already exists", "name", config.Name)
+		return nil
+	}
+
+	server := NewSSEServer(config.Name, config, p.logger)
+	p.servers[config.Name] = server
+
+	p.logger.Info("sse_pool: server created", "name", config.Name, "url", config.HTTP.URL)
+
+	go func() {
+		initCtx, cancel := context.WithTimeout(p.ctx, 30*time.Second)
+		defer cancel()
+		if err := server.Initialize(initCtx); err != nil {
+			p.logger.Warn("sse_pool: failed to initialize server", "name", config.Name, "error", err)
+		}
+	}()
+
+	return nil
+}
+
+func (p *SSEPool) ListServers() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	names := make([]string, 0, len(p.servers))
+	for name := range p.servers {
+		names = append(names, name)
+	}
+	return names
+}
+
+func (p *SSEPool) GetServerState(name string) (ServerState, error) {
+	p.mu.RLock()
+	server, exists := p.servers[name]
+	p.mu.RUnlock()
+
+	if !exists {
+		return "", fmt.Errorf("sse_pool: server %s not found", name)
+	}
+
+	return server.getState(), nil
+}
+
+func (p *SSEPool) SendRequest(ctx context.Context, serverName string, req *proxy.JSONRPCRequest, timeout time.Duration) (*proxy.JSONRPCResponse, error) {
+	p.mu.RLock()
+	server, exists := p.servers[serverName]
+	p.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("sse_pool: server %s not found", serverName)
+	}
+
+	toolArgs := make(map[string]interface{})
+	if req.Params != nil {
+		_ = json.Unmarshal(req.Params, &toolArgs)
+	}
+
+	result, err := server.CallTool(ctx, req.Method, toolArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	resultBytes, _ := json.Marshal(result)
+	return &proxy.JSONRPCResponse{
+		JSONRPC: "2.0",
+		Result:  resultBytes,
+		ID:      req.ID,
+	}, nil
+}
+
+func (p *SSEPool) SendRequestToServer(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration) (*Response, error) {
+	return p.SendRequestToServerWithID(ctx, name, method, params, timeout, 1)
+}
+
+func (p *SSEPool) SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error) {
+	p.mu.RLock()
+	server, exists := p.servers[name]
+	p.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("sse_pool: server %s not found", name)
+	}
+
+	if server.mcpClient == nil {
+		initCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		if err := server.Initialize(initCtx); err != nil {
+			return nil, err
+		}
+	}
+
+	toolArgs := make(map[string]interface{})
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &toolArgs)
+	}
+
+	result, err := server.CallTool(ctx, method, toolArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	resultBytes, _ := json.Marshal(result)
+	return &Response{
+		Result: resultBytes,
+		ID:     id,
+	}, nil
+}
+
+func (p *SSEPool) SendServerNotification(ctx context.Context, name string, method string, params map[string]interface{}) error {
+	return nil
+}
+
+func (p *SSEPool) RestartServer(ctx context.Context, name string) error {
+	p.mu.RLock()
+	server, exists := p.servers[name]
+	p.mu.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("sse_pool: server %s not found", name)
+	}
+
+	server.setState(StateRunning)
+	p.logger.Info("sse_pool: server restarted", "name", name)
+	return nil
+}
+
+func (p *SSEPool) Close() error {
+	p.cancel()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, server := range p.servers {
+		server.Close()
+	}
+	p.servers = make(map[string]*SSEServer)
+	return nil
+}
+
+func (p *SSEPool) ServerCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.servers)
+}
+
+var _ ServerSource = (*SSEPool)(nil)

--- a/pkg/utils/token_estimator.go
+++ b/pkg/utils/token_estimator.go
@@ -136,7 +136,7 @@ func (t *TokenEstimator) CompareMCPConfigurations(servers map[string]MCPServerCo
 	var serverBreakdown []MCPServerAnalysis
 
 	avgToolsPerServer := 35
-	for name, _ := range servers {
+	for name := range servers {
 		serverTokens := t.EstimateNativeMCPOverhead(name, avgToolsPerServer)
 		totalNativeTokens += serverTokens
 		serverBreakdown = append(serverBreakdown, MCPServerAnalysis{


### PR DESCRIPTION
## Summary

- Add HTTP server support (StreamableHTTP) to tool caching system using mcp-go client library
- Add SSE server support to tool caching system using mcp-go client library  
- Create `HTTPClientPool` and `HTTPClientServer` to manage HTTP MCP servers
- Create `SSEPool` and `SSEServer` to manage SSE MCP servers
- Create `UnifiedPool` to handle stdio, HTTP, and SSE servers under a single interface
- Update `Handler` to use `ServerSource` interface for tool caching
- Add proper HTTP header support for authenticated servers (e.g., GitHub PAT)

## Problem

The tool caching mechanism only works for stdio servers because:
1. Only stdio servers are added to the `StdioPool`
2. HTTP/SSE servers are handled separately via the registry but never queried for tools
3. The `ListServers()` method only returns servers from the stdio pool

## Solution

1. Created `HTTPClientPool` to manage StreamableHTTP servers using mcp-go client
   - Supports custom headers (Authorization, etc.)
   - Handles tools/list specially using mcp-go's ListTools() method
   - Returns properly formatted ListToolsResult for cache parsing
2. Created `SSEPool` to manage SSE-based MCP servers using mcp-go client
3. Created `UnifiedPool` that combines all three pools (stdio, HTTP, SSE)
4. Added `ServerSource` interface to pool.go for generic pool access
5. Updated the tool caching logic to use `ServerSource` which returns all servers
6. Fixed routing in UnifiedPool to use HasServer() method to check server ownership

## Files Changed

- `pkg/pool/http_pool.go` (new): HTTP server pool implementation with StreamableHTTP client
- `pkg/pool/sse_pool.go` (new): SSE server pool implementation
- `pkg/pool/pool.go`: Added ServerSource interface and HasServer method to StdioPool
- `pkg/mcp/handlers.go`: Updated to use ServerSource interface
- `cmd/serve.go`: Added HTTP and SSE server initialization with unified pool
- `cmd/server.go`: Added HTTP and SSE server support
- `cmd/status.go`: Updated to show status for all server types

## Testing

Verify by running:
```bash
leanproxy-mcp serve &
sleep 8
leanproxy-mcp cache --list
# Should show: github, mcp-atlassian, stitch
leanproxy-mcp status --running
# Should show all servers running
```