### PR TITLE
fix: properly handle tools/call method in HTTP and SSE pools

### DIFF
--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -278,6 +278,25 @@ func (p *HTTPClientPool) SendRequestToServerWithID(ctx context.Context, name str
 		}, nil
 	}
 
+	if method == "tools/call" {
+		var toolParams struct {
+			Name      string                 `json:"name"`
+			Arguments map[string]interface{} `json:"arguments"`
+		}
+		if err := json.Unmarshal(params, &toolParams); err != nil {
+			return nil, fmt.Errorf("http_pool: invalid tools/call params: %w", err)
+		}
+		result, err := server.CallTool(ctx, toolParams.Name, toolParams.Arguments)
+		if err != nil {
+			return nil, err
+		}
+		resultBytes, _ := json.Marshal(result)
+		return &Response{
+			Result: resultBytes,
+			ID:     id,
+		}, nil
+	}
+
 	toolArgs := make(map[string]interface{})
 	if len(params) > 0 {
 		_ = json.Unmarshal(params, &toolArgs)

--- a/pkg/pool/sse_pool.go
+++ b/pkg/pool/sse_pool.go
@@ -265,6 +265,38 @@ func (p *SSEPool) SendRequestToServerWithID(ctx context.Context, name string, me
 		}
 	}
 
+	if method == "tools/list" {
+		tools, err := server.ListTools(ctx)
+		if err != nil {
+			return nil, err
+		}
+		result := mcp.ListToolsResult{Tools: tools}
+		resultBytes, _ := json.Marshal(result)
+		return &Response{
+			Result: resultBytes,
+			ID:     id,
+		}, nil
+	}
+
+	if method == "tools/call" {
+		var toolParams struct {
+			Name      string                 `json:"name"`
+			Arguments map[string]interface{} `json:"arguments"`
+		}
+		if err := json.Unmarshal(params, &toolParams); err != nil {
+			return nil, fmt.Errorf("sse_pool: invalid tools/call params: %w", err)
+		}
+		result, err := server.CallTool(ctx, toolParams.Name, toolParams.Arguments)
+		if err != nil {
+			return nil, err
+		}
+		resultBytes, _ := json.Marshal(result)
+		return &Response{
+			Result: resultBytes,
+			ID:     id,
+		}, nil
+	}
+
 	toolArgs := make(map[string]interface{})
 	if len(params) > 0 {
 		_ = json.Unmarshal(params, &toolArgs)


### PR DESCRIPTION
## Problem

When invoking tools on HTTP/SSE servers, the error occurs:
```
invalid params: unknown tool "tools/call"
```

This is because the `tools/call` method was being passed as the tool name to `CallTool()` instead of extracting the actual tool name from the params.

## Solution

Parse the `tools/call` params to extract:
- `name`: the actual tool name to invoke
- `arguments`: the tool arguments

Then call `server.CallTool(ctx, toolName, args)` with the extracted values.

## Files Changed

- `pkg/pool/http_pool.go`: Added special handling for `tools/call` method
- `pkg/pool/sse_pool.go`: Added special handling for `tools/call` method