### PR TITLE
feat: enhance MCP tool discovery with better tool index, defaults, and error hints

### DIFF
--- a/pkg/mcp/error_hints.go
+++ b/pkg/mcp/error_hints.go
@@ -1,0 +1,180 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ErrorHint struct {
+	Original   string
+	Suggestion string
+	Action    string
+	Reference string
+}
+
+var ErrorHintRegistry = map[string][]ErrorHint{
+	"repository": {
+		{
+			Original:   "Could not resolve to a Repository",
+			Suggestion: "Check the owner/repo spelling. Ensure the repository exists and you have access. Tip: Use the exact format 'owner/repo' (e.g., 'mmornati/leanproxy-mcp').",
+			Action:    "check_repo",
+			Reference: "https://docs.github.com/en/github/finding-open-source-projects-on-github",
+		},
+	},
+	"not running": {
+		{
+			Original:   "is not running",
+			Suggestion: "The MCP server is not running. Run 'leanproxy server start <server_name>' or check server status with 'leanproxy status'.",
+			Action:    "restart_server",
+		},
+	},
+	"failed": {
+		{
+			Original:   "server error",
+			Suggestion: "The remote server encountered an error. Try again in a few moments, or check the server logs for more details.",
+			Action:    "retry",
+		},
+	},
+	"not authenticated": {
+		{
+			Original:   "not authenticated",
+			Suggestion: "Authentication required. Check your credentials configuration for this server.",
+			Action:    "check_auth",
+		},
+		{
+			Original:   "401",
+			Suggestion: "Authentication failed. Verify your API token or credentials are correct.",
+			Action:    "check_auth",
+		},
+	},
+	"forbidden": {
+		{
+			Original:   "403",
+			Suggestion: "Access denied. You may not have permission for this operation. Check your API token scopes.",
+			Action:    "check_permissions",
+		},
+		{
+			Original:   "permission denied",
+			Suggestion: "Insufficient permissions. Verify your account has the required access rights.",
+			Action:    "check_permissions",
+		},
+	},
+	"not found": {
+		{
+			Original:   "404",
+			Suggestion: "The requested resource was not found. Check if the resource exists and the URL is correct.",
+			Action:    "verify_resource",
+		},
+	},
+	"rate limited": {
+		{
+			Original:   "429",
+			Suggestion: "Rate limit exceeded. Wait a moment before retrying, or check if you need to configure rate limiting.",
+			Action:    "wait_retry",
+		},
+		{
+			Original:   "rate limit",
+			Suggestion: "Too many requests. Consider adding a delay between requests or reducing request frequency.",
+			Action:    "wait_retry",
+		},
+	},
+	"timeout": {
+		{
+			Original:   "timeout",
+			Suggestion: "The request timed out. The server may be slow or unavailable. Try again or increase timeout settings.",
+			Action:    "retry",
+		},
+		{
+			Original:   "context deadline exceeded",
+			Suggestion: "The request took too long. Try again or check if the server is experiencing issues.",
+			Action:    "retry",
+		},
+	},
+	"invalid params": {
+		{
+			Original:   "invalid params",
+			Suggestion: "Check the parameter names and types. Refer to search_tools output for available parameters.",
+			Action:    "check_params",
+		},
+		{
+			Original:   "missing",
+			Suggestion: "A required parameter is missing. Check search_tools output for required parameters.",
+			Action:    "check_params",
+		},
+	},
+	"connection refused": {
+		{
+			Original:   "connection refused",
+			Suggestion: "Cannot connect to the server. Verify the server is running and the connection settings are correct.",
+			Action:    "check_server",
+		},
+	},
+	"tool not found": {
+		{
+			Original:   "tool not found",
+			Suggestion: "The tool doesn't exist on this server. Use search_tools to discover available tools.",
+			Action:    "search_tools",
+		},
+	},
+}
+
+func EnrichError(originalMessage string) string {
+	originalLower := strings.ToLower(originalMessage)
+
+	for pattern, hints := range ErrorHintRegistry {
+		patternLower := strings.ToLower(pattern)
+		if strings.Contains(originalLower, patternLower) {
+			hint := hints[0]
+			return fmt.Sprintf("%s\n\n💡 %s", originalMessage, hint.Suggestion)
+		}
+	}
+
+	return originalMessage
+}
+
+func GetErrorHint(originalMessage string) *ErrorHint {
+	originalLower := strings.ToLower(originalMessage)
+
+	for pattern, hints := range ErrorHintRegistry {
+		patternLower := strings.ToLower(pattern)
+		if strings.Contains(originalLower, patternLower) {
+			hint := hints[0]
+			return &hint
+		}
+	}
+
+	return nil
+}
+
+func GetAllHintsForError(originalMessage string) []ErrorHint {
+	originalLower := strings.ToLower(originalMessage)
+
+	for pattern, hints := range ErrorHintRegistry {
+		patternLower := strings.ToLower(pattern)
+		if strings.Contains(originalLower, patternLower) {
+			return hints
+		}
+	}
+
+	return nil
+}
+
+func AddErrorContext(originalMessage, serverName, toolName string) string {
+	if serverName != "" || toolName != "" {
+		context := "\n\n📋 Context:"
+		if serverName != "" {
+			context += fmt.Sprintf("\n  Server: %s", serverName)
+		}
+		if toolName != "" {
+			context += fmt.Sprintf("\n  Tool: %s", toolName)
+		}
+		return originalMessage + context
+	}
+
+	return originalMessage
+}
+
+func FormatErrorWithHint(originalMessage, serverName, toolName string) string {
+	enriched := EnrichError(originalMessage)
+	return AddErrorContext(enriched, serverName, toolName)
+}

--- a/pkg/mcp/error_hints_test.go
+++ b/pkg/mcp/error_hints_test.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestEnrichError(t *testing.T) {
+	tests := []struct {
+		name            string
+		original       string
+		wantContains   string
+		wantHintEmoji bool
+	}{
+		{
+			name:            "repository not found",
+			original:        "Could not resolve to a Repository with the name 'anomalyco/leanproxy-mcp'",
+			wantContains:    "Check the owner/repo spelling",
+			wantHintEmoji: true,
+		},
+		{
+			name:            "server not running",
+			original:        "server github is not running (state: stopped)",
+			wantContains:   "Run 'leanproxy server start",
+			wantHintEmoji: true,
+		},
+		{
+			name:            "no match",
+			original:       "some random error",
+			wantContains:   "some random error",
+			wantHintEmoji: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EnrichError(tt.original)
+			if tt.wantHintEmoji {
+				if len(got) <= len(tt.original) {
+					t.Errorf("EnrichError() = %v, original was not enriched", got)
+				}
+			}
+			if got == "" {
+				t.Error("EnrichError() should not return empty string")
+			}
+		})
+	}
+}
+
+func TestGetErrorHint(t *testing.T) {
+	hint := GetErrorHint("Could not resolve to a Repository")
+	if hint == nil {
+		t.Fatal("hint should not be nil for repository not found")
+	}
+
+	if hint.Suggestion == "" {
+		t.Error("hint should have suggestion")
+	}
+
+	if hint.Action == "" {
+		t.Error("hint should have action")
+	}
+}
+
+func TestGetErrorHintNoMatch(t *testing.T) {
+	hint := GetErrorHint("random unrelated error")
+	if hint != nil {
+		t.Errorf("GetErrorHint() = %v, want nil", hint)
+	}
+}
+
+func TestFormatErrorWithHint(t *testing.T) {
+	result := FormatErrorWithHint("test error", "github", "github_list_issues")
+	if result == "" {
+		t.Error("result should not be empty")
+	}
+
+	if len(result) <= len("test error") {
+		t.Error("result should contain additional context")
+	}
+}
+
+func TestAddErrorContext(t *testing.T) {
+	result := AddErrorContext("original error", "github", "list_issues")
+	if result == "" {
+		t.Error("result should not be empty")
+	}
+}
+
+func TestAddErrorContextEmpty(t *testing.T) {
+	result := AddErrorContext("original error", "", "")
+	if result != "original error" {
+		t.Error("result should be unchanged when no context provided")
+	}
+}

--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -147,17 +147,13 @@ func (h *Handler) handleInitialize(ctx context.Context, req *Request) (*Response
 func (h *Handler) handleToolsList(ctx context.Context, req *Request) (*Response, error) {
 	h.logger.Debug("tools/list request received, returning gateway tools only")
 
-	gatewayTools := []Tool{
-		{
-			Name:        "search_tools",
-			Description: "Search for tools across all configured MCP servers. Returns tool names, descriptions, and parameters. Always call this first to discover available tools before invoking.",
-			InputSchema: json.RawMessage(`{"type":"object","properties":{"query":{"type":"string","description":"Search query (e.g., 'activity', 'sleep', 'garmin')"}},"required":["query"]}`),
-		},
-		{
-			Name:        "invoke_tool",
-			Description: "Invoke a tool on a configured MCP server. First use search_tools to find the server_name and tool_name, then pass the tool arguments.",
-			InputSchema: json.RawMessage(`{"type":"object","properties":{"server":{"type":"string","description":"Server name from search_tools (e.g., 'garmin', 'Intervals.icu')"},"tool":{"type":"string","description":"Tool name from search_tools (e.g., 'garmin_get_activities')"},"arguments":{"type":"object","description":"Tool arguments as key-value pairs"}},"required":["server","tool"]}`),
-		},
+	gatewayTools := make([]Tool, 0)
+	for _, def := range GetAllToolDefinitions() {
+		gatewayTools = append(gatewayTools, Tool{
+			Name:        def.Name,
+			Description: def.Description,
+			InputSchema: def.InputSchema,
+		})
 	}
 
 	result := ToolsListResult{Tools: gatewayTools}
@@ -293,6 +289,7 @@ func (h *Handler) handleSearchTools(ctx context.Context, req *Request, params To
 	if params.Arguments != nil {
 		var args map[string]interface{}
 		if err := json.Unmarshal(params.Arguments, &args); err == nil {
+			args = ApplyDefaults("search_tools", args)
 			if q, ok := args["query"].(string); ok {
 				query = q
 			}
@@ -300,6 +297,26 @@ func (h *Handler) handleSearchTools(ctx context.Context, req *Request, params To
 				maxDescChars = int(m)
 			}
 		}
+	}
+
+	if query == "" {
+		return &Response{
+			JSONRPC: JSONRPCVersion,
+			Error:   NewError(ErrCodeInvalidParams, "query parameter is required. Use search_tools to discover available tools."),
+			ID:      req.ID,
+		}, nil
+	}
+
+	if valid, msg := ValidateParam("search_tools", "max_description_chars", float64(maxDescChars)); !valid {
+		return &Response{
+			JSONRPC: JSONRPCVersion,
+			Error:   NewError(ErrCodeInvalidParams, fmt.Sprintf("max_description_chars %s", msg)),
+			ID:      req.ID,
+		}, nil
+	}
+
+	if maxDescChars == 0 {
+		maxDescChars = 200
 	}
 
 	h.logger.Info("search_tools called", "query", query, "max_desc_chars", maxDescChars)
@@ -487,6 +504,7 @@ func (h *Handler) handleInvokeTool(ctx context.Context, req *Request, params Too
 	if params.Arguments != nil {
 		var args map[string]interface{}
 		if err := json.Unmarshal(params.Arguments, &args); err == nil {
+			args = ApplyDefaults("invoke_tool", args)
 			if s, ok := args["server"].(string); ok {
 				serverName = s
 			}
@@ -505,7 +523,7 @@ func (h *Handler) handleInvokeTool(ctx context.Context, req *Request, params Too
 	if serverName == "" || toolName == "" {
 		return &Response{
 			JSONRPC: JSONRPCVersion,
-			Error:   NewError(ErrCodeInvalidParams, "server and tool are required"),
+			Error:   NewError(ErrCodeInvalidParams, "server and tool are required. Use search_tools to discover available tools."),
 			ID:      req.ID,
 		}, nil
 	}
@@ -523,9 +541,13 @@ func (h *Handler) handleInvokeTool(ctx context.Context, req *Request, params Too
 		h.logger.Warn("server not running, attempting to restart", "name", serverName, "state", state)
 		if err := h.pool.RestartServer(ctx, serverName); err != nil {
 			h.logger.Error("failed to restart server", "name", serverName, "error", err)
+			enrichedError := FormatErrorWithHint(
+				fmt.Sprintf("server %s is not running (state: %s) and failed to restart: %v", serverName, state, err),
+				serverName, toolName,
+			)
 			return &Response{
 				JSONRPC: JSONRPCVersion,
-				Error:   NewError(ErrCodeServerError, fmt.Sprintf("server %s is not running (state: %s) and failed to restart: %v", serverName, state, err)),
+				Error:   NewError(ErrCodeServerError, enrichedError),
 				ID:      req.ID,
 			}, nil
 		}
@@ -543,7 +565,8 @@ func (h *Handler) handleInvokeTool(ctx context.Context, req *Request, params Too
 	if err != nil {
 		h.logger.Error("invoke_tool failed", "server", serverName, "tool", toolName, "error", err)
 		schema := h.lookupToolSchema(serverName, toolName)
-		errResp := NewError(ErrCodeServerError, fmt.Sprintf("tool invocation failed: %v", err))
+		enrichedError := FormatErrorWithHint(fmt.Sprintf("tool invocation failed: %v", err), serverName, toolName)
+		errResp := NewError(ErrCodeServerError, enrichedError)
 		if schema != nil {
 			dataBytes, _ := json.Marshal(map[string]interface{}{
 				"tool":   toolName,
@@ -561,7 +584,8 @@ func (h *Handler) handleInvokeTool(ctx context.Context, req *Request, params Too
 	if resp.Error != nil {
 		h.logger.Error("invoke_tool received error from server", "server", serverName, "tool", toolName, "error", resp.Error.Message)
 		schema := h.lookupToolSchema(serverName, toolName)
-		errResp := NewError(ErrCodeServerError, fmt.Sprintf("tool invocation failed: %s", resp.Error.Message))
+		enrichedError := FormatErrorWithHint(fmt.Sprintf("tool invocation failed: %s", resp.Error.Message), serverName, toolName)
+		errResp := NewError(ErrCodeServerError, enrichedError)
 		if schema != nil {
 			dataBytes, _ := json.Marshal(map[string]interface{}{
 				"tool":   toolName,

--- a/pkg/mcp/tool_defaults.go
+++ b/pkg/mcp/tool_defaults.go
@@ -1,0 +1,127 @@
+package mcp
+
+type ParameterMeta struct {
+	Required        bool
+	Default        interface{}
+	Min            interface{}
+	Max            interface{}
+	Description   string
+	SuggestedValues []string
+}
+
+var SearchToolsParamDefaults = map[string]interface{}{
+	"max_description_chars": 200,
+}
+
+var SearchToolsParamMeta = map[string]ParameterMeta{
+	"query": {
+		Required:      true,
+		Default:      nil,
+		Description:  "Search query (e.g., 'github issues', 'garmin activities', 'filesystem'). Supports fuzzy matching across tool names and descriptions.",
+		SuggestedValues: []string{"github", "filesystem", "garmin", "intervals", "productivity"},
+	},
+	"max_description_chars": {
+		Required:    false,
+		Default:     200,
+		Min:         50,
+		Max:         500,
+		Description: "Maximum characters for tool descriptions. Default: 200. Range: 50-500.",
+	},
+}
+
+var InvokeToolParamDefaults = map[string]interface{}{}
+
+var InvokeToolParamMeta = map[string]ParameterMeta{
+	"server": {
+		Required:    true,
+		Description: "Server name from search_tools (e.g., 'github', 'garmin', 'filesystem'). Must be a configured and running MCP server.",
+	},
+	"tool": {
+		Required:    true,
+		Description: "Tool name from search_tools (e.g., 'github_list_issues', 'garmin_get_activities'). Do NOT prefix with server name.",
+	},
+	"arguments": {
+		Required:    false,
+		Description: "Tool arguments as key-value pairs. Refer to search_tools output for available parameters. Pass empty object {} if no arguments needed.",
+	},
+}
+
+func GetParamDefault(toolName, paramName string) interface{} {
+	switch toolName {
+	case "search_tools":
+		return SearchToolsParamDefaults[paramName]
+	case "invoke_tool":
+		return InvokeToolParamDefaults[paramName]
+	}
+	return nil
+}
+
+func GetParamMeta(toolName, paramName string) *ParameterMeta {
+	switch toolName {
+	case "search_tools":
+		if meta, ok := SearchToolsParamMeta[paramName]; ok {
+			return &meta
+		}
+	case "invoke_tool":
+		if meta, ok := InvokeToolParamMeta[paramName]; ok {
+			return &meta
+		}
+	}
+	return nil
+}
+
+func ApplyDefaults(toolName string, args map[string]interface{}) map[string]interface{} {
+	if args == nil {
+		args = make(map[string]interface{})
+	}
+
+	switch toolName {
+	case "search_tools":
+		if _, hasKey := args["max_description_chars"]; !hasKey {
+			args["max_description_chars"] = SearchToolsParamDefaults["max_description_chars"]
+		}
+	case "invoke_tool":
+		// No defaults for invoke_tool - all params required or user-dependent
+	}
+
+	return args
+}
+
+func GetAllParamDefaults(toolName string) map[string]interface{} {
+	switch toolName {
+	case "search_tools":
+		return SearchToolsParamDefaults
+	case "invoke_tool":
+		return InvokeToolParamDefaults
+	}
+	return nil
+}
+
+func ValidateParam(toolName, paramName string, value interface{}) (bool, string) {
+	meta := GetParamMeta(toolName, paramName)
+	if meta == nil {
+		return true, ""
+	}
+
+	if meta.Required && value == nil {
+		return false, "parameter is required"
+	}
+
+	if value == nil {
+		return true, ""
+	}
+
+	switch paramName {
+	case "max_description_chars":
+		if fval, ok := value.(float64); ok {
+			if fval == 0 {
+				return true, ""
+			}
+			if fval < 50 || fval > 500 {
+				return false, "must be between 50 and 500"
+			}
+		}
+	}
+
+	return true, ""
+}

--- a/pkg/mcp/tool_defaults_test.go
+++ b/pkg/mcp/tool_defaults_test.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestApplyDefaults(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  string
+		args     map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "search_tools with no max_description_chars",
+			toolName: "search_tools",
+			args:    map[string]interface{}{"query": "github"},
+			expected: map[string]interface{}{"query": "github", "max_description_chars": 200},
+		},
+		{
+			name:     "search_tools with existing max_description_chars",
+			toolName: "search_tools",
+			args:    map[string]interface{}{"query": "github", "max_description_chars": float64(100)},
+			expected: map[string]interface{}{"query": "github", "max_description_chars": float64(100)},
+		},
+		{
+			name:     "search_tools with nil args",
+			toolName: "search_tools",
+			args:    nil,
+			expected: map[string]interface{}{"max_description_chars": 200},
+		},
+		{
+			name:     "invoke_tool with empty args",
+			toolName: "invoke_tool",
+			args:    map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ApplyDefaults(tt.toolName, tt.args)
+			for key, expectedVal := range tt.expected {
+				if got[key] != expectedVal {
+					t.Errorf("ApplyDefaults()[%s] = %v, want %v", key, got[key], expectedVal)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateParam(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName string
+		param   string
+		value   interface{}
+		wantOk  bool
+	}{
+		{
+			name:      "valid max_description_chars",
+			toolName: "search_tools",
+			param:   "max_description_chars",
+			value:   float64(100),
+			wantOk:  true,
+		},
+		{
+			name:      "max_description_chars below min",
+			toolName: "search_tools",
+			param:   "max_description_chars",
+			value:   float64(30),
+			wantOk:  false,
+		},
+		{
+			name:      "max_description_chars above max",
+			toolName: "search_tools",
+			param:   "max_description_chars",
+			value:   float64(600),
+			wantOk:  false,
+		},
+		{
+			name:      "edge case min",
+			toolName: "search_tools",
+			param:   "max_description_chars",
+			value:   float64(50),
+			wantOk:  true,
+		},
+		{
+			name:      "edge case max",
+			toolName: "search_tools",
+			param:   "max_description_chars",
+			value:   float64(500),
+			wantOk:  true,
+		},
+		{
+			name:      "zero value should pass",
+			toolName: "search_tools",
+			param:   "max_description_chars",
+			value:   float64(0),
+			wantOk:  true,
+		},
+		{
+			name:      "nil value should pass",
+			toolName: "search_tools",
+			param:   "max_description_chars",
+			value:   nil,
+			wantOk:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := ValidateParam(tt.toolName, tt.param, tt.value)
+			if got != tt.wantOk {
+				t.Errorf("ValidateParam() = %v, want %v", got, tt.wantOk)
+			}
+		})
+	}
+}
+
+func TestGetParamMeta(t *testing.T) {
+	meta := GetParamMeta("search_tools", "query")
+	if meta == nil {
+		t.Fatal("meta should not be nil")
+	}
+
+	if !meta.Required {
+		t.Error("query should be required")
+	}
+
+	if meta.Description == "" {
+		t.Error("query should have description")
+	}
+
+	meta = GetParamMeta("search_tools", "max_description_chars")
+	if meta == nil {
+		t.Fatal("meta should not be nil for max_description_chars")
+	}
+
+	if meta.Default != 200 {
+		t.Errorf("max_description_chars default = %v, want 200", meta.Default)
+	}
+}
+
+func TestGetAllParamDefaults(t *testing.T) {
+	defaults := GetAllParamDefaults("search_tools")
+	if defaults == nil {
+		t.Fatal("defaults should not be nil")
+	}
+
+	if defaults["max_description_chars"] != 200 {
+		t.Errorf("max_description_chars default = %v, want 200", defaults["max_description_chars"])
+	}
+}

--- a/pkg/mcp/tool_index.go
+++ b/pkg/mcp/tool_index.go
@@ -1,0 +1,153 @@
+package mcp
+
+import "encoding/json"
+
+type ToolDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Examples    []ToolExample  `json:"examples,omitempty"`
+	Returns     ReturnSchema   `json:"returns,omitempty"`
+	Categories  []string      `json:"categories,omitempty"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+type ToolExample struct {
+	Input       map[string]interface{} `json:"input"`
+	Description string                `json:"description"`
+}
+
+type ReturnSchema struct {
+	Type         string            `json:"type"`
+	Description string            `json:"description"`
+	Fields       []FieldDescription `json:"fields,omitempty"`
+}
+
+type FieldDescription struct {
+	Name     string `json:"name"`
+	Type    string `json:"type"`
+	Req     bool   `json:"required,omitempty"`
+	Desc    string `json:"description"`
+}
+
+var LeanproxyTools = []ToolDefinition{
+	{
+		Name:        "search_tools",
+		Description: "Search for tools across all configured MCP servers. **IMPORTANT:** Always call this first to discover available server_name and tool_name before invoking any tool. Returns tool names, descriptions, and parameters.",
+		Categories:  []string{"discovery", "meta"},
+		Examples: []ToolExample{
+			{
+				Input: map[string]interface{}{
+					"query": "github",
+				},
+				Description: "Find all tools related to GitHub operations",
+			},
+			{
+				Input: map[string]interface{}{
+					"query":        "activity",
+					"max_description_chars": 150,
+				},
+				Description: "Search for 'activity' tools with shorter descriptions",
+			},
+			{
+				Input: map[string]interface{}{
+					"query": "issues",
+				},
+				Description: "Find all issue-tracking tools across servers",
+			},
+		},
+		Returns: ReturnSchema{
+			Type:        "object",
+			Description: "Returns a content block with formatted tool results",
+			Fields: []FieldDescription{
+				{Name: "content", Type: "array", Desc: "Array of text content blocks"},
+			},
+		},
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"query": {
+					"type": "string",
+					"description": "Search query (e.g., 'github issues', 'garmin activities', 'filesystem'). Supports fuzzy matching."
+				},
+				"max_description_chars": {
+					"type": "number",
+					"description": "Maximum characters for tool descriptions (default: 200, min: 50, max: 500)",
+					"default": 200
+				}
+			},
+			"required": ["query"]
+		}`),
+	},
+	{
+		Name:        "invoke_tool",
+		Description: "Invoke a tool on a configured MCP server. **Required:** First use search_tools to discover server_name and tool_name, then pass them as arguments.",
+		Categories:  []string{"execution", "meta"},
+		Examples: []ToolExample{
+			{
+				Input: map[string]interface{}{
+					"server": "github",
+					"tool":   "github_list_issues",
+					"arguments": map[string]interface{}{
+						"owner":  "mmornati",
+						"repo":   "leanproxy-mcp",
+						"state":  "open",
+						"perPage": 10,
+					},
+				},
+				Description: "List open issues on leanproxy-mcp repository",
+			},
+			{
+				Input: map[string]interface{}{
+					"server": "github",
+					"tool":   "github_search_issues",
+					"arguments": map[string]interface{}{
+						"query":  "is:issue is:open label:bug",
+						"owner":  "mmornati",
+						"repo":   "leanproxy-mcp",
+						"perPage": 5,
+					},
+				},
+				Description: "Search for open bug issues",
+			},
+		},
+		Returns: ReturnSchema{
+			Type:        "object",
+			Description: "Returns the result from the remote MCP tool invocation",
+			Fields: []FieldDescription{
+				{Name: "content", Type: "array", Desc: "Array of content blocks from tool"},
+			},
+		},
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"server": {
+					"type": "string",
+					"description": "Server name from search_tools (e.g., 'github', 'garmin', 'filesystem'). Must be a configured MCP server."
+				},
+				"tool": {
+					"type": "string",
+					"description": "Tool name from search_tools (e.g., 'github_list_issues', 'garmin_get_activities'). Do NOT prefix with server name."
+				},
+				"arguments": {
+					"type": "object",
+					"description": "Tool arguments as key-value pairs. Refer to search_tools output for available parameters."
+				}
+			},
+			"required": ["server", "tool"],
+			"additionalProperties": false
+		}`),
+	},
+}
+
+func GetToolDefinition(name string) *ToolDefinition {
+	for i := range LeanproxyTools {
+		if LeanproxyTools[i].Name == name {
+			return &LeanproxyTools[i]
+		}
+	}
+	return nil
+}
+
+func GetAllToolDefinitions() []ToolDefinition {
+	return LeanproxyTools
+}

--- a/pkg/mcp/tool_index_test.go
+++ b/pkg/mcp/tool_index_test.go
@@ -1,0 +1,79 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestGetToolDefinition(t *testing.T) {
+	tests := []struct {
+		name       string
+		searchName string
+		wantNil   bool
+	}{
+		{
+			name:       "search_tools exists",
+			searchName: "search_tools",
+			wantNil:   false,
+		},
+		{
+			name:       "invoke_tool exists",
+			searchName: "invoke_tool",
+			wantNil:   false,
+		},
+		{
+			name:       "non_existent tool",
+			searchName: "fake_tool",
+			wantNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetToolDefinition(tt.searchName)
+			if (got == nil) != tt.wantNil {
+				t.Errorf("GetToolDefinition() = %v, want nil=%v", got, tt.wantNil)
+			}
+		})
+	}
+}
+
+func TestGetAllToolDefinitions(t *testing.T) {
+	tools := GetAllToolDefinitions()
+	if len(tools) != 2 {
+		t.Errorf("GetAllToolDefinitions() = %d tools, want 2", len(tools))
+	}
+}
+
+func TestToolDefinitionFields(t *testing.T) {
+	searchTools := GetToolDefinition("search_tools")
+	if searchTools == nil {
+		t.Fatal("search_tools should not be nil")
+	}
+
+	if searchTools.Name != "search_tools" {
+		t.Errorf("Name = %s, want search_tools", searchTools.Name)
+	}
+
+	if len(searchTools.Examples) == 0 {
+		t.Error("search_tools should have examples")
+	}
+
+	if searchTools.InputSchema == nil {
+		t.Error("search_tools should have InputSchema")
+	}
+}
+
+func TestInvokeToolDefinition(t *testing.T) {
+	invokeTool := GetToolDefinition("invoke_tool")
+	if invokeTool == nil {
+		t.Fatal("invoke_tool should not be nil")
+	}
+
+	if len(invokeTool.Examples) == 0 {
+		t.Error("invoke_tool should have examples")
+	}
+
+	if len(invokeTool.Categories) == 0 {
+		t.Error("invoke_tool should have categories")
+	}
+}


### PR DESCRIPTION
## Summary
- Add enhanced tool index with descriptions, examples, and categories
- Add default parameter values and validation logic
- Add error enrichment with helpful suggestions
- Update handlers to use new components

## Changes

### Point 1: Better Tool Index
- **New file:** `pkg/mcp/tool_index.go`
  - `ToolDefinition` struct with `Name`, `Description`, `Examples`, `Returns`, `Categories`, `InputSchema`
  - `LeanproxyTools` - static definitions for gateway tools (`search_tools`, `invoke_tool`)
  - Each tool includes 2-3 real usage examples

### Point 2: Default Values & Parameters  
- **New file:** `pkg/mcp/tool_defaults.go`
  - `SearchToolsParamDefaults` with sensible defaults (`max_description_chars: 200`)
  - `ValidateParam()` for parameter validation (min/max range checking)
  - `ApplyDefaults()` to automatically fill missing params

### Point 3: Error Enrichment
- **New file:** `pkg/mcp/error_hints.go`
  - `ErrorHintRegistry` with common error patterns and suggestions
  - `EnrichError()` adds 💡 hints to error messages
  - `FormatErrorWithHint()` adds server/tool context (📋)

### Integration
- **Modified:** `pkg/mcp/handlers.go`
  - `handleToolsList()` now uses `GetAllToolDefinitions()` from tool_index
  - `handleSearchTools()` uses `ApplyDefaults()` and validates params
  - `handleInvokeTool()` uses `FormatErrorWithHint()` for error enrichment

### Tests
- Added comprehensive tests for all new packages

## Testing
- All 29 tests pass
- `go vet` passes with no issues
- Build succeeds

## Example Enhanced Error

**Before:**
```
Could not resolve to a Repository with the name 'anomalyco/leanproxy-mcp'
```

**After:**
```
Could not resolve to a Repository with the name 'anomalyco/leanproxy-mcp'

💡 Check the owner/repo spelling. Ensure the repository exists and you have access. 
Tip: Use the exact format 'owner/repo' (e.g., 'mmornati/leanproxy-mcp').

📋 Context:
  Server: github
  Tool: github_list_issues
```