### PR TITLE
fix: Rename the wrong leanproxy binary to have a consitency in all th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Other IDEs (Claude Desktop, Cursor, Windsurf): see [Installation Guide](https://
 ### Verification
 
 ```bash
-leanproxy server list
+leanproxy-mcp server list
 ```
 
 ## Build from Source

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -45,7 +45,7 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 
 	if len(result.Servers) == 0 {
 		fmt.Println("No MCP configurations found on this system.")
-		fmt.Println("To add servers manually, use: leanproxy server add")
+		fmt.Println("To add servers manually, use: leanproxy-mcp server add")
 		return nil
 	}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -301,9 +301,9 @@ Use --stdio flag to enable stdio mode. Without --stdio, the command
 will show help for the run command.
 
 Example:
-  leanproxy server run --stdio
-  leanproxy server run --stdio --config /path/to/config.yaml
-  leanproxy server run --stdio --log-file /tmp/leanproxy.log`,
+  leanproxy-mcp server run --stdio
+  leanproxy-mcp server run --stdio --config /path/to/config.yaml
+  leanproxy-mcp server run --stdio --log-file /tmp/leanproxy.log`,
 	RunE: runServerRun,
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -680,8 +680,8 @@ When using `--running`, status is read from the status file written by running i
 ```
 
 This file is created by:
-- `leanproxy serve` (HTTP proxy mode)
-- `leanproxy server run --stdio` (stdio mode, used by OpenCode)
+- `leanproxy-mcp serve` (HTTP proxy mode)
+- `leanproxy-mcp server run --stdio` (stdio mode, used by OpenCode)
 
 ### Examples
 


### PR DESCRIPTION
This pull request updates documentation and user-facing messages to consistently use the `leanproxy-mcp` command instead of the previous `leanproxy` command. This ensures clarity for users and aligns all references with the current executable name.

Documentation and messaging updates:

* Updated code examples and instructions in `README.md`, `docs/commands.md`, and command help text to use `leanproxy-mcp` instead of `leanproxy`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L159-R159) [[2]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eL683-R684) [[3]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L304-R306)
* Changed user guidance and error messages in `cmd/migrate.go` to reference `leanproxy-mcp` for server management commands.