### PR TITLE
fix: add graceful shutdown to lifecycleManager.reapprocesses (closes #113)

### DIFF
--- a/pkg/registry/lifecycle.go
+++ b/pkg/registry/lifecycle.go
@@ -52,6 +52,7 @@ type LifecycleManager interface {
 	Restart(ctx context.Context, id string) error
 	Status(ctx context.Context, id string) (ServerStatus, error)
 	List(ctx context.Context) ([]ServerStatus, error)
+	Close()
 }
 
 type serverEntry struct {
@@ -67,13 +68,17 @@ type lifecycleManager struct {
 	servers map[string]*serverEntry
 	logger  *slog.Logger
 	mu      sync.RWMutex
+	stopCh  chan struct{}
+	wg      sync.WaitGroup
 }
 
 func NewLifecycleManager(logger *slog.Logger) LifecycleManager {
 	m := &lifecycleManager{
 		servers: make(map[string]*serverEntry),
 		logger:  logger,
+		stopCh:  make(chan struct{}),
 	}
+	m.wg.Add(1)
 	go m.reapProcesses()
 	return m
 }
@@ -260,19 +265,34 @@ func (m *lifecycleManager) List(ctx context.Context) ([]ServerStatus, error) {
 }
 
 func (m *lifecycleManager) reapProcesses() {
-	for range time.Tick(5 * time.Second) {
-		m.mu.Lock()
-		for id, entry := range m.servers {
-			entry.mu.RLock()
-			state := entry.status.State
-			entry.mu.RUnlock()
-			if state == StateStopped || state == StateError {
-				delete(m.servers, id)
-				m.logger.Debug("reaped dead server", "id", id)
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			m.mu.Lock()
+			for id, entry := range m.servers {
+				entry.mu.RLock()
+				state := entry.status.State
+				entry.mu.RUnlock()
+				if state == StateStopped || state == StateError {
+					delete(m.servers, id)
+					m.logger.Debug("reaped dead server", "id", id)
+				}
 			}
+			m.mu.Unlock()
+		case <-m.stopCh:
+			return
 		}
-		m.mu.Unlock()
 	}
+}
+
+func (m *lifecycleManager) Close() {
+	close(m.stopCh)
+	m.wg.Wait()
 }
 
 func getProcessStats(pid int) (float64, float64, error) {

--- a/pkg/registry/lifecycle_test.go
+++ b/pkg/registry/lifecycle_test.go
@@ -266,4 +266,19 @@ func TestProcessAlreadyExited(t *testing.T) {
 	if entry != nil {
 		t.Log("Server still in registry after quick exit")
 	}
+
+	manager.Close()
+}
+
+func TestLifecycleManagerClose(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	manager := NewLifecycleManager(logger).(*lifecycleManager)
+
+	manager.Close()
+
+	select {
+	case <-manager.stopCh:
+	default:
+		t.Error("stopCh should be closed after Close()")
+	}
 }


### PR DESCRIPTION
## Summary

Fix goroutine leak in lifecycleManager.reapProcesses() by adding graceful shutdown support.

## Problem

The reapProcesses goroutine was started when NewLifecycleManager was called but never stopped, causing a goroutine leak.

## Solution

Following the same pattern as issue #112:

1. Added stopCh channel and WaitGroup to lifecycleManager struct
2. Modified reapProcesses to use select with ticker and stop channel
3. Added Close() method to LifecycleManager interface

## Changes

- pkg/registry/lifecycle.go: Added Close() method and stop mechanism
- pkg/registry/lifecycle_test.go: Added TestLifecycleManagerClose test

## Acceptance Criteria

- [x] LifecycleManager has a Close() method for graceful shutdown
- [x] No goroutine leak when LifecycleManager is closed
- [x] All existing tests pass
- [x] Tests pass with -race flag

Part of Epic 8: Resource Management & Goroutine Leaks (#107)