### PR TITLE
Story 8.4: Track readResponses goroutine with WaitGroup

### DIFF
--- a/pkg/pool/server.go
+++ b/pkg/pool/server.go
@@ -65,6 +65,7 @@ type StdioServerV2 struct {
 	stopped        bool
 	logger         *slog.Logger
 	stopChOnce     sync.Once
+	wg             sync.WaitGroup
 }
 
 func newServerV2(name string, config StdioServerConfig, logger *slog.Logger) *StdioServerV2 {
@@ -156,13 +157,16 @@ func (s *StdioServerV2) spawn(ctx context.Context) error {
 
 	s.mu.Unlock()
 
+	s.wg.Add(1)
 	go s.waitForExit(ctx)
+	s.wg.Add(1)
 	go s.readResponses()
 
 	return nil
 }
 
 func (s *StdioServerV2) waitForExit(ctx context.Context) {
+	defer s.wg.Done()
 	err := s.process.Wait()
 
 	s.mu.Lock()
@@ -219,6 +223,7 @@ func (s *StdioServerV2) scheduleRestart(ctx context.Context) {
 }
 
 func (s *StdioServerV2) readResponses() {
+	defer s.wg.Done()
 	scanner := bufio.NewScanner(s.stdout)
 	scanner.Buffer(make([]byte, 1024), 50*1024*1024)
 
@@ -277,6 +282,8 @@ func (s *StdioServerV2) stop() error {
 	if s.process != nil && s.process.Process != nil {
 		s.process.Process.Signal(syscall.SIGTERM)
 	}
+
+	s.wg.Wait()
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Implemented WaitGroup tracking for goroutines in `StdioServerV2` to ensure proper graceful shutdown coordination.

### Changes Made

- **pkg/pool/server.go**:
  - Added `wg sync.WaitGroup` field to `StdioServerV2` struct (line 68)
  - Added `s.wg.Add(1)` before spawning `waitForExit` and `readResponses` goroutines in `spawn()` (lines 160-163)
  - Added `defer s.wg.Done()` to both goroutines for automatic cleanup on return
  - Added `s.wg.Wait()` call in `stop()` method to wait for all goroutines to complete before returning

### Implementation Details

The implementation follows existing patterns from `pkg/proxy/proxy.go:112` and `pkg/concurrent/worker.go:16`:

1. **Tracking**: Both goroutines are tracked with `wg.Add(1)` before spawning
2. **Cleanup**: Both goroutines use `defer wg.Done()` for guaranteed cleanup
3. **Coordination**: `stop()` now calls `wg.Wait()` to ensure all spawned goroutines have completed before the method returns

### Acceptance Criteria

- [x] readResponses goroutine tracked with WaitGroup
- [x] waitForExit goroutine tracked with WaitGroup  
- [x] Proper graceful shutdown with Wait()
- [x] All existing tests pass (pool package: 19 tests pass with `-race` flag)
- [x] go vet shows no issues

**Note**: The failing `TestHandlerShutdown` test in `pkg/proxy/socket` is a pre-existing issue unrelated to these changes (verified by running tests before and after the changes).

### Related

- Part of Epic 8: Resource Management & Goroutine Leaks (#107)
- Closes #116