### PR TITLE
feat(socket): add authentication to socket server methods (closes #117)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,16 @@ watch:
 | `server.port` | int | `8080` | Listen port |
 | `server.timeout` | duration | `30s` | Request timeout |
 
+### Socket Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `socket.path` | string | `"~/.leanproxy/leanproxy.sock"` | Unix socket path |
+| `socket.perm` | int | `0700` | Socket file permissions |
+| `socket.max_msg_size` | int | `1048576` (1MB) | Maximum message size |
+| `socket.rate_limit` | int | `100` | Rate limit (requests/second) |
+| `socket.auth_token` | string | `""` | Authentication token (empty = no auth) |
+
 ### Bouncer (Redaction) Options
 
 | Option | Type | Default | Description |
@@ -121,6 +131,54 @@ Output:
   - bearer-token: JWT Bearer token (three base64url segments)
   - env-var-value: Environment variable assignment
 ```
+
+## Socket Authentication
+
+The socket server supports optional token-based authentication to prevent unauthorized access.
+
+### Enabling Authentication
+
+To enable authentication, set the `auth_token` in your socket configuration:
+
+```yaml
+socket:
+  auth_token: "your-secret-token"
+```
+
+### Using Authenticated Requests
+
+When authentication is enabled, all JSON-RPC requests must include the `auth_token` field:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "token.resolve",
+  "params": {"uri": "api://example"},
+  "id": 1,
+  "auth_token": "your-secret-token"
+}
+```
+
+### Error Responses
+
+When authentication fails (missing or invalid token), the server returns:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32604,
+    "message": "authentication required"
+  }
+}
+```
+
+### Security Notes
+
+- Without an auth token configured, all requests are allowed
+- The auth token is transmitted in plain text - use TLS or Unix socket permissions for security
+- Token comparison is exact (no hashing)
 
 ## Custom Redaction Patterns
 

--- a/pkg/proxy/socket/server.go
+++ b/pkg/proxy/socket/server.go
@@ -17,10 +17,11 @@ import (
 )
 
 type jsonRPCRequest struct {
-	JSONRPC string          `json:"jsonrpc"`
-	Method  string          `json:"method"`
-	Params  json.RawMessage `json:"params,omitempty"`
-	ID      interface{}     `json:"id"`
+	JSONRPC  string          `json:"jsonrpc"`
+	Method   string          `json:"method"`
+	Params   json.RawMessage `json:"params,omitempty"`
+	ID       interface{}     `json:"id"`
+	AuthToken string         `json:"auth_token,omitempty"`
 }
 
 type jsonRPCResponse struct {
@@ -42,6 +43,7 @@ const (
 	ErrCodeMethodNotFound = -32601
 	ErrCodeInvalidParams  = -32602
 	ErrCodeInternalError  = -32603
+	ErrCodeUnauthorized   = -32604
 )
 
 type MethodHandler func(ctx context.Context, params json.RawMessage) (interface{}, error)
@@ -175,6 +177,11 @@ func (s *Server) handleRequest(conn net.Conn, data []byte, reader *bufio.Reader)
 		return
 	}
 
+	if !s.Authenticate(req.AuthToken) {
+		s.sendError(conn, req.ID, ErrCodeUnauthorized, "authentication required")
+		return
+	}
+
 	s.mu.RLock()
 	handler, ok := s.methods[req.Method]
 	s.mu.RUnlock()
@@ -241,6 +248,13 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 func (s *Server) Addr() net.Addr {
 	return s.listener.Addr()
+}
+
+func (s *Server) Authenticate(token string) bool {
+	if s.config.AuthToken == "" {
+		return true
+	}
+	return token == s.config.AuthToken
 }
 
 func (s *Server) getTransport() (string, string) {

--- a/pkg/proxy/socket/server_test.go
+++ b/pkg/proxy/socket/server_test.go
@@ -358,3 +358,256 @@ func TestMessageTooLarge(t *testing.T) {
 	defer shutdownCancel()
 	server.Shutdown(shutdownCtx)
 }
+
+func TestAuthenticateWithToken(t *testing.T) {
+	config := ServerConfig{
+		Path:       "/tmp/test.sock",
+		Perm:       0700,
+		MaxMsgSize: 1024 * 1024,
+		AuthToken:  "secret-token",
+	}
+
+	server, err := NewServer(config, nil)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	if !server.Authenticate("secret-token") {
+		t.Error("Expected valid token to authenticate")
+	}
+
+	if server.Authenticate("wrong-token") {
+		t.Error("Expected invalid token to fail authentication")
+	}
+}
+
+func TestAuthenticateNoTokenConfigured(t *testing.T) {
+	config := ServerConfig{
+		Path:       "/tmp/test.sock",
+		Perm:       0700,
+		MaxMsgSize: 1024 * 1024,
+	}
+
+	server, err := NewServer(config, nil)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	if !server.Authenticate("any-token") {
+		t.Error("Expected any token to succeed when no auth token configured")
+	}
+}
+
+func TestRequestWithAuthToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	config := ServerConfig{
+		Path:       socketPath,
+		Perm:       0700,
+		MaxMsgSize: 1024 * 1024,
+		AuthToken:  "my-secret-token",
+	}
+
+	server, err := NewServer(config, nil)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	server.RegisterMethod("test.echo", func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+		return map[string]string{"echo": "ok"}, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		server.Serve(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	req := `{"jsonrpc":"2.0","method":"test.echo","params":{},"id":1,"auth_token":"my-secret-token"}`
+	_, err = fmt.Fprintf(conn, "%s\n", req)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	resp := make([]byte, 4096)
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := conn.Read(resp)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	var rpcResp map[string]interface{}
+	if err := json.Unmarshal(resp[:n], &rpcResp); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if rpcResp["id"] != float64(1) {
+		t.Errorf("Expected id 1, got %v", rpcResp["id"])
+	}
+
+	if rpcResp["error"] != nil {
+		t.Error("Expected successful response with valid token")
+	}
+
+	conn.Close()
+	cancel()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	server.Shutdown(shutdownCtx)
+}
+
+func TestRequestWithoutAuthToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	config := ServerConfig{
+		Path:       socketPath,
+		Perm:       0700,
+		MaxMsgSize: 1024 * 1024,
+		AuthToken:  "my-secret-token",
+	}
+
+	server, err := NewServer(config, nil)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	server.RegisterMethod("test.echo", func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+		return map[string]string{"echo": "ok"}, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		server.Serve(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	req := `{"jsonrpc":"2.0","method":"test.echo","params":{},"id":1}`
+	_, err = fmt.Fprintf(conn, "%s\n", req)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	resp := make([]byte, 4096)
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := conn.Read(resp)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	var rpcResp map[string]interface{}
+	if err := json.Unmarshal(resp[:n], &rpcResp); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if rpcResp["id"] != float64(1) {
+		t.Errorf("Expected id 1, got %v", rpcResp["id"])
+	}
+
+	errObj, ok := rpcResp["error"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected error response when auth token missing")
+	}
+
+	if errObj["code"].(float64) != -32604 {
+		t.Errorf("Expected error code -32604 (unauthorized), got %v", errObj["code"])
+	}
+
+	conn.Close()
+	cancel()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	server.Shutdown(shutdownCtx)
+}
+
+func TestRequestWithInvalidAuthToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	config := ServerConfig{
+		Path:       socketPath,
+		Perm:       0700,
+		MaxMsgSize: 1024 * 1024,
+		AuthToken:  "my-secret-token",
+	}
+
+	server, err := NewServer(config, nil)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	server.RegisterMethod("test.echo", func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+		return map[string]string{"echo": "ok"}, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		server.Serve(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	req := `{"jsonrpc":"2.0","method":"test.echo","params":{},"id":1,"auth_token":"wrong-token"}`
+	_, err = fmt.Fprintf(conn, "%s\n", req)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	resp := make([]byte, 4096)
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := conn.Read(resp)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	var rpcResp map[string]interface{}
+	if err := json.Unmarshal(resp[:n], &rpcResp); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if rpcResp["id"] != float64(1) {
+		t.Errorf("Expected id 1, got %v", rpcResp["id"])
+	}
+
+	errObj, ok := rpcResp["error"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected error response when auth token is invalid")
+	}
+
+	if errObj["code"].(float64) != -32604 {
+		t.Errorf("Expected error code -32604 (unauthorized), got %v", errObj["code"])
+	}
+
+	conn.Close()
+	cancel()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	server.Shutdown(shutdownCtx)
+}

--- a/pkg/proxy/socket/socket.go
+++ b/pkg/proxy/socket/socket.go
@@ -9,6 +9,7 @@ type SocketServer interface {
 	Serve(ctx context.Context) error
 	Shutdown(ctx context.Context) error
 	Addr() net.Addr
+	Authenticate(token string) bool
 }
 
 type ServerConfig struct {
@@ -16,6 +17,7 @@ type ServerConfig struct {
 	Perm       uint32
 	MaxMsgSize int64
 	RateLimit  int
+	AuthToken  string
 }
 
 func DefaultConfig() ServerConfig {


### PR DESCRIPTION
## Summary

Implements token-based authentication for the socket server as described in issue #117.

### Changes

1. **SocketServer Interface** (`pkg/proxy/socket/socket.go`)
   - Added `Authenticate(token string) bool` method to interface

2. **ServerConfig** (`pkg/proxy/socket/socket.go`)
   - Added `AuthToken` field for configuring authentication

3. **Server Implementation** (`pkg/proxy/socket/server.go`)
   - Added `ErrCodeUnauthorized` error code (-32604)
   - Added `auth_token` field to `jsonRPCRequest` struct
   - Implemented `Authenticate()` method that validates tokens
   - Added auth checking in `handleRequest()` before processing requests

4. **Tests** (`pkg/proxy/socket/server_test.go`)
   - Added `TestAuthenticateWithToken` - tests valid/invalid token authentication
   - Added `TestAuthenticateNoTokenConfigured` - tests behavior when no token configured
   - Added `TestRequestWithAuthToken` - integration test for authenticated requests
   - Added `TestRequestWithoutAuthToken` - tests rejection of unauthenticated requests
   - Added `TestRequestWithInvalidAuthToken` - tests rejection of invalid tokens

5. **Documentation** (`docs/configuration.md`)
   - Added Socket Options table
   - Added Socket Authentication section with configuration examples

### Behavior

**When AuthToken is configured:**
- Requests without `auth_token` field are rejected with error code -32604
- Requests with invalid `auth_token` are rejected with error code -32604  
- Requests with valid `auth_token` are processed normally

**When AuthToken is empty (default):**
- All requests are allowed without authentication (backward compatible)

### Example Usage

Configure authentication:
```yaml
socket:
  auth_token: "your-secret-token"
```

Send authenticated request:
```json
{
  "jsonrpc": "2.0",
  "method": "token.resolve",
  "params": {"uri": "api://example"},
  "id": 1,
  "auth_token": "your-secret-token"
}
```

Error response for authentication failure:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32604,
    "message": "authentication required"
  }
}
```

## Checklist

- [x] Socket server has Authenticate() method
- [x] Requests can be rejected without valid auth token
- [x] Config supports auth token
- [x] Tests verify auth works
- [x] Documentation updated
- [x] CI tests pass

Closes #117