### PR TITLE
feat(proxy): implement batch size limits to prevent DoS (closes #118)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -318,7 +318,7 @@ func handleSingleRequestAsync(ctx context.Context, line []byte, writer *bufio.Wr
 }
 
 func handleBatchRequest(ctx context.Context, line []byte, writer *bufio.Writer, r Router, gt gateway.GatewayTools, p Pool) {
-	reqs, err := proxy.ParseJSONRPCBatchRequest(line)
+	reqs, err := proxy.ParseJSONRPCBatchRequest(line, GetConfig().MaxBatchSize)
 	if err != nil {
 		writeError(writer, proxy.ErrCodeParseError, "Parse error")
 		return
@@ -482,10 +482,12 @@ func writeError(writer *bufio.Writer, code int, message string) {
 
 type ServeConfig struct {
 	RequestTimeout time.Duration
+	MaxBatchSize  int
 }
 
 var serveConfig = &ServeConfig{
 	RequestTimeout: 30 * time.Second,
+	MaxBatchSize:   100,
 }
 
 func GetConfig() *ServeConfig {
@@ -495,6 +497,9 @@ func GetConfig() *ServeConfig {
 func SetConfig(cfg *ServeConfig) {
 	if cfg != nil && cfg.RequestTimeout > 0 {
 		serveConfig.RequestTimeout = cfg.RequestTimeout
+	}
+	if cfg != nil && cfg.MaxBatchSize > 0 {
+		serveConfig.MaxBatchSize = cfg.MaxBatchSize
 	}
 }
 
@@ -528,7 +533,7 @@ func writeErrorAsync(writer *bufio.Writer, mu *sync.Mutex, code int, message str
 }
 
 func handleBatchRequestAsync(ctx context.Context, line []byte, writer *bufio.Writer, writerMu *sync.Mutex, r Router, gt gateway.GatewayTools, p Pool) {
-	reqs, err := proxy.ParseJSONRPCBatchRequest(line)
+	reqs, err := proxy.ParseJSONRPCBatchRequest(line, GetConfig().MaxBatchSize)
 	if err != nil {
 		writeErrorAsync(writer, writerMu, proxy.ErrCodeParseError, "Parse error")
 		return

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,7 @@ watch:
 | `server.host` | string | `"127.0.0.1"` | Listen host |
 | `server.port` | int | `8080` | Listen port |
 | `server.timeout` | duration | `30s` | Request timeout |
+| `server.max_batch_size` | int | `100` | Maximum batch size for JSON-RPC batch requests (0 = unlimited) |
 
 ### Socket Options
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -195,10 +195,13 @@ func IsBatchRequest(data []byte) bool {
 	return false
 }
 
-func ParseJSONRPCBatchRequest(data []byte) ([]JSONRPCRequest, error) {
+func ParseJSONRPCBatchRequest(data []byte, maxBatchSize int) ([]JSONRPCRequest, error) {
 	var reqs []JSONRPCRequest
 	if err := json.Unmarshal(data, &reqs); err != nil {
 		return nil, fmt.Errorf("proxy: parse batch request: %w", err)
+	}
+	if maxBatchSize > 0 && len(reqs) > maxBatchSize {
+		return nil, fmt.Errorf("proxy: batch size %d exceeds limit %d", len(reqs), maxBatchSize)
 	}
 	return reqs, nil
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -175,13 +176,119 @@ func TestParseJSONRPCBatchRequest(t *testing.T) {
 		{"jsonrpc":"2.0","method":"test2","id":2}
 	]`)
 
-	reqs, err := ParseJSONRPCBatchRequest(data)
+	reqs, err := ParseJSONRPCBatchRequest(data, 0)
 	if err != nil {
 		t.Fatalf("ParseJSONRPCBatchRequest() failed: %v", err)
 	}
 	if len(reqs) != 2 {
 		t.Errorf("expected 2 requests, got %d", len(reqs))
 	}
+}
+
+func TestParseJSONRPCBatchRequestSizeLimit(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		maxBatchSize int
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "within limit",
+			data: []byte(`[
+				{"jsonrpc":"2.0","method":"test","id":1},
+				{"jsonrpc":"2.0","method":"test2","id":2}
+			]`),
+			maxBatchSize: 5,
+			wantErr:      false,
+		},
+		{
+			name: "exactly at limit",
+			data: []byte(`[
+				{"jsonrpc":"2.0","method":"test","id":1},
+				{"jsonrpc":"2.0","method":"test2","id":2}
+			]`),
+			maxBatchSize: 2,
+			wantErr:      false,
+		},
+		{
+			name: "exceeds limit",
+			data: []byte(`[
+				{"jsonrpc":"2.0","method":"test","id":1},
+				{"jsonrpc":"2.0","method":"test2","id":2},
+				{"jsonrpc":"2.0","method":"test3","id":3}
+			]`),
+			maxBatchSize: 2,
+			wantErr:      true,
+			errContains: "batch size 3 exceeds limit 2",
+		},
+		{
+			name:        "zero limit disables check",
+			data:        []byte(`[{"jsonrpc":"2.0","method":"test","id":1},{"jsonrpc":"2.0","method":"test2","id":2},{"jsonrpc":"2.0","method":"test3","id":3}]`),
+			maxBatchSize: 0,
+			wantErr:      false,
+		},
+		{
+			name:        "large batch within limit",
+			data:        []byte(`[` + generateLargeBatch(50) + `]`),
+			maxBatchSize: 100,
+			wantErr:      false,
+		},
+		{
+			name:        "large batch exceeds limit",
+			data:        []byte(`[` + generateLargeBatch(150) + `]`),
+			maxBatchSize: 100,
+			wantErr:      true,
+			errContains: "batch size 150 exceeds limit 100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqs, err := ParseJSONRPCBatchRequest(tt.data, tt.maxBatchSize)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseJSONRPCBatchRequest() expected error, got nil")
+				} else if tt.errContains != "" {
+					if err.Error() != "" && !contains(err.Error(), tt.errContains) {
+						t.Errorf("ParseJSONRPCBatchRequest() error = %v, want contains %q", err, tt.errContains)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParseJSONRPCBatchRequest() unexpected error: %v", err)
+			}
+			if reqs == nil {
+				t.Error("ParseJSONRPCBatchRequest() returned nil reqs")
+			}
+		})
+	}
+}
+
+func generateLargeBatch(count int) string {
+	result := ""
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			result += ","
+		}
+		result += fmt.Sprintf(`{"jsonrpc":"2.0","method":"test%d","id":%d}`, i, i)
+	}
+	return result
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }
 
 func TestNewJSONRPCError(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements configurable batch request size limits to prevent DoS attacks, as specified in issue #118.

### Changes Made

1. **pkg/proxy/proxy.go**: Updated `ParseJSONRPCBatchRequest` to accept a `maxBatchSize` parameter and validate the batch size against this limit.

2. **cmd/serve.go**: Added `MaxBatchSize` field to `ServeConfig` with a default of 100. Updated both `handleBatchRequest` and `handleBatchRequestAsync` to pass the configured limit to the parser.

3. **pkg/proxy/proxy_test.go**: Added comprehensive tests for the batch size limit feature:
   - Within limit test
   - Exactly at limit test  
   - Exceeds limit test (verifies proper error)
   - Zero limit (disables check)
   - Large batch within limit
   - Large batch exceeds limit

4. **docs/configuration.md**: Documented the new `server.max_batch_size` configuration option.

### Acceptance Criteria

- [x] Batch requests have configurable size limit
- [x] Requests exceeding limit return proper error
- [x] Default limit is sensible (100)
- [x] Tests verify limit works

### Security Note

This change prevents DoS attacks where an attacker could send massive JSON-RPC batch requests containing unlimited requests to overwhelm the proxy.

---

Part of Epic 9: Security Hardening (#108)