### PR TITLE
feat: consolidate duplicate JSONRPCError type definitions (Story 11.3)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 	"github.com/mmornati/leanproxy-mcp/pkg/gateway"
 	"github.com/mmornati/leanproxy-mcp/pkg/mcp"
 	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
@@ -253,7 +254,7 @@ func handleConnection(conn io.ReadWriter, r Router, gt gateway.GatewayTools, p P
 func handleSingleRequest(ctx context.Context, line []byte, writer *bufio.Writer, r Router, gt gateway.GatewayTools, p Pool) {
 	req, err := proxy.ParseJSONRPCRequest(line)
 	if err != nil {
-		writeError(writer, proxy.ErrCodeParseError, "Parse error")
+		writeError(writer, errors.ErrCodeParseError, "Parse error")
 		return
 	}
 
@@ -264,7 +265,7 @@ func handleSingleRequest(ctx context.Context, line []byte, writer *bufio.Writer,
 
 	server, err := r.Route(ctx, req.Method)
 	if err != nil {
-		writeError(writer, proxy.ErrCodeMethodNotFound, "Method not found")
+		writeError(writer, errors.ErrCodeMethodNotFound, "Method not found")
 		return
 	}
 
@@ -275,7 +276,7 @@ func handleSingleRequest(ctx context.Context, line []byte, writer *bufio.Writer,
 
 	resp, err := p.SendRequest(ctx, server.ID, req, timeout)
 	if err != nil {
-		writeError(writer, proxy.ErrCodeInternalError, err.Error())
+		writeError(writer, errors.ErrCodeInternalError, err.Error())
 		return
 	}
 
@@ -285,7 +286,7 @@ func handleSingleRequest(ctx context.Context, line []byte, writer *bufio.Writer,
 func handleSingleRequestAsync(ctx context.Context, line []byte, writer *bufio.Writer, writerMu *sync.Mutex, r Router, gt gateway.GatewayTools, p Pool) {
 	req, err := proxy.ParseJSONRPCRequest(line)
 	if err != nil {
-		writeErrorAsync(writer, writerMu, proxy.ErrCodeParseError, "Parse error")
+		writeErrorAsync(writer, writerMu, errors.ErrCodeParseError, "Parse error")
 		return
 	}
 
@@ -299,7 +300,7 @@ func handleSingleRequestAsync(ctx context.Context, line []byte, writer *bufio.Wr
 
 	server, err := r.Route(ctx, req.Method)
 	if err != nil {
-		writeErrorAsync(writer, writerMu, proxy.ErrCodeMethodNotFound, "Method not found")
+		writeErrorAsync(writer, writerMu, errors.ErrCodeMethodNotFound, "Method not found")
 		return
 	}
 
@@ -310,7 +311,7 @@ func handleSingleRequestAsync(ctx context.Context, line []byte, writer *bufio.Wr
 
 	resp, err := p.SendRequest(ctx, server.ID, req, timeout)
 	if err != nil {
-		writeErrorAsync(writer, writerMu, proxy.ErrCodeInternalError, err.Error())
+		writeErrorAsync(writer, writerMu, errors.ErrCodeInternalError, err.Error())
 		return
 	}
 
@@ -320,12 +321,12 @@ func handleSingleRequestAsync(ctx context.Context, line []byte, writer *bufio.Wr
 func handleBatchRequest(ctx context.Context, line []byte, writer *bufio.Writer, r Router, gt gateway.GatewayTools, p Pool) {
 	reqs, err := proxy.ParseJSONRPCBatchRequest(line, GetConfig().MaxBatchSize)
 	if err != nil {
-		writeError(writer, proxy.ErrCodeParseError, "Parse error")
+		writeError(writer, errors.ErrCodeParseError, "Parse error")
 		return
 	}
 
 	if len(reqs) == 0 {
-		writeError(writer, proxy.ErrCodeInvalidRequest, "Empty batch")
+		writeError(writer, errors.ErrCodeInvalidRequest, "Empty batch")
 		return
 	}
 
@@ -348,7 +349,7 @@ func handleBatchRequest(ctx context.Context, line []byte, writer *bufio.Writer, 
 		if err != nil {
 			responses = append(responses, &proxy.JSONRPCResponse{
 				JSONRPC: "2.0",
-				Error:   proxy.NewJSONRPCError(proxy.ErrCodeMethodNotFound, "Method not found"),
+				Error:   errors.NewJSONRPCError(errors.ErrCodeMethodNotFound, "Method not found"),
 				ID:      req.ID,
 			})
 			continue
@@ -362,7 +363,7 @@ func handleBatchRequest(ctx context.Context, line []byte, writer *bufio.Writer, 
 		if err != nil {
 			responses = append(responses, &proxy.JSONRPCResponse{
 				JSONRPC: "2.0",
-				Error:   proxy.NewJSONRPCError(proxy.ErrCodeInternalError, err.Error()),
+				Error:   errors.NewJSONRPCError(errors.ErrCodeInternalError, err.Error()),
 				ID:      req.ID,
 			})
 			continue
@@ -373,7 +374,7 @@ func handleBatchRequest(ctx context.Context, line []byte, writer *bufio.Writer, 
 
 	data, err := json.Marshal(responses)
 	if err != nil {
-		writeError(writer, proxy.ErrCodeInternalError, "Failed to marshal batch response")
+		writeError(writer, errors.ErrCodeInternalError, "Failed to marshal batch response")
 		return
 	}
 
@@ -402,7 +403,7 @@ func handleGatewayToolSync(ctx context.Context, req *proxy.JSONRPCRequest, gt ga
 		if listErr != nil {
 			return &proxy.JSONRPCResponse{
 				JSONRPC: "2.0",
-				Error:   proxy.NewJSONRPCError(proxy.ErrCodeInternalError, listErr.Error()),
+				Error:   errors.NewJSONRPCError(errors.ErrCodeInternalError, listErr.Error()),
 				ID:      req.ID,
 			}
 		}
@@ -418,7 +419,7 @@ func handleGatewayToolSync(ctx context.Context, req *proxy.JSONRPCRequest, gt ga
 		if searchErr != nil {
 			return &proxy.JSONRPCResponse{
 				JSONRPC: "2.0",
-				Error:   proxy.NewJSONRPCError(proxy.ErrCodeInternalError, searchErr.Error()),
+				Error:   errors.NewJSONRPCError(errors.ErrCodeInternalError, searchErr.Error()),
 				ID:      req.ID,
 			}
 		}
@@ -430,7 +431,7 @@ func handleGatewayToolSync(ctx context.Context, req *proxy.JSONRPCRequest, gt ga
 		}
 		invokeResult, invokeErr := gt.InvokeTool(ctx, params)
 		if invokeErr != nil {
-			if rpcErr, ok := invokeErr.(*proxy.JSONRPCError); ok {
+			if rpcErr, ok := invokeErr.(*errors.JSONRPCError); ok {
 				return &proxy.JSONRPCResponse{
 					JSONRPC: "2.0",
 					Error:   rpcErr,
@@ -439,7 +440,7 @@ func handleGatewayToolSync(ctx context.Context, req *proxy.JSONRPCRequest, gt ga
 			}
 			return &proxy.JSONRPCResponse{
 				JSONRPC: "2.0",
-				Error:   proxy.NewJSONRPCError(proxy.ErrCodeInternalError, invokeErr.Error()),
+				Error:   errors.NewJSONRPCError(errors.ErrCodeInternalError, invokeErr.Error()),
 				ID:      req.ID,
 			}
 		}
@@ -469,7 +470,7 @@ func writeResponse(writer *bufio.Writer, resp *proxy.JSONRPCResponse) {
 func writeError(writer *bufio.Writer, code int, message string) {
 	resp := &proxy.JSONRPCResponse{
 		JSONRPC: "2.0",
-		Error:   proxy.NewJSONRPCError(code, message),
+		Error:   errors.NewJSONRPCError(code, message),
 		ID:      nil,
 	}
 	data, err := json.Marshal(resp)
@@ -518,7 +519,7 @@ func writeResponseAsync(writer *bufio.Writer, mu *sync.Mutex, resp *proxy.JSONRP
 func writeErrorAsync(writer *bufio.Writer, mu *sync.Mutex, code int, message string) {
 	resp := &proxy.JSONRPCResponse{
 		JSONRPC: "2.0",
-		Error:   proxy.NewJSONRPCError(code, message),
+		Error:   errors.NewJSONRPCError(code, message),
 		ID:      nil,
 	}
 	mu.Lock()
@@ -535,12 +536,12 @@ func writeErrorAsync(writer *bufio.Writer, mu *sync.Mutex, code int, message str
 func handleBatchRequestAsync(ctx context.Context, line []byte, writer *bufio.Writer, writerMu *sync.Mutex, r Router, gt gateway.GatewayTools, p Pool) {
 	reqs, err := proxy.ParseJSONRPCBatchRequest(line, GetConfig().MaxBatchSize)
 	if err != nil {
-		writeErrorAsync(writer, writerMu, proxy.ErrCodeParseError, "Parse error")
+		writeErrorAsync(writer, writerMu, errors.ErrCodeParseError, "Parse error")
 		return
 	}
 
 	if len(reqs) == 0 {
-		writeErrorAsync(writer, writerMu, proxy.ErrCodeInvalidRequest, "Empty batch")
+		writeErrorAsync(writer, writerMu, errors.ErrCodeInvalidRequest, "Empty batch")
 		return
 	}
 
@@ -563,7 +564,7 @@ func handleBatchRequestAsync(ctx context.Context, line []byte, writer *bufio.Wri
 		if err != nil {
 			responses = append(responses, &proxy.JSONRPCResponse{
 				JSONRPC: "2.0",
-				Error:   proxy.NewJSONRPCError(proxy.ErrCodeMethodNotFound, "Method not found"),
+				Error:   errors.NewJSONRPCError(errors.ErrCodeMethodNotFound, "Method not found"),
 				ID:      req.ID,
 			})
 			continue
@@ -577,7 +578,7 @@ func handleBatchRequestAsync(ctx context.Context, line []byte, writer *bufio.Wri
 		if err != nil {
 			responses = append(responses, &proxy.JSONRPCResponse{
 				JSONRPC: "2.0",
-				Error:   proxy.NewJSONRPCError(proxy.ErrCodeInternalError, err.Error()),
+				Error:   errors.NewJSONRPCError(errors.ErrCodeInternalError, err.Error()),
 				ID:      req.ID,
 			})
 			continue
@@ -588,7 +589,7 @@ func handleBatchRequestAsync(ctx context.Context, line []byte, writer *bufio.Wri
 
 	data, err := json.Marshal(responses)
 	if err != nil {
-		writeErrorAsync(writer, writerMu, proxy.ErrCodeInternalError, "Failed to marshal batch response")
+		writeErrorAsync(writer, writerMu, errors.ErrCodeInternalError, "Failed to marshal batch response")
 		return
 	}
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 	"github.com/mmornati/leanproxy-mcp/pkg/gateway"
 	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
 	"github.com/mmornati/leanproxy-mcp/pkg/registry"
@@ -156,7 +157,7 @@ func TestWriteError(t *testing.T) {
 	readBuf := &bytes.Buffer{}
 	writer := bufio.NewWriter(readBuf)
 
-	writeError(writer, proxy.ErrCodeMethodNotFound, "Method not found")
+	writeError(writer, errors.ErrCodeMethodNotFound, "Method not found")
 	writer.Flush()
 
 	output := readBuf.String()
@@ -170,8 +171,8 @@ func TestWriteError(t *testing.T) {
 		t.Fatal("expected error in response")
 	}
 
-	if parsed.Error.Code != proxy.ErrCodeMethodNotFound {
-		t.Errorf("expected error code %d, got %d", proxy.ErrCodeMethodNotFound, parsed.Error.Code)
+	if parsed.Error.Code != errors.ErrCodeMethodNotFound {
+		t.Errorf("expected error code %d, got %d", errors.ErrCodeMethodNotFound, parsed.Error.Code)
 	}
 
 	if parsed.Error.Message != "Method not found" {
@@ -264,8 +265,8 @@ func TestHandleConnection_ParseError(t *testing.T) {
 		t.Fatal("expected error response for malformed JSON")
 	}
 
-	if resp.Error.Code != proxy.ErrCodeParseError {
-		t.Errorf("expected parse error code %d, got %d", proxy.ErrCodeParseError, resp.Error.Code)
+	if resp.Error.Code != errors.ErrCodeParseError {
+		t.Errorf("expected parse error code %d, got %d", errors.ErrCodeParseError, resp.Error.Code)
 	}
 }
 
@@ -283,7 +284,7 @@ func TestHandleConnection_EOF(t *testing.T) {
 func TestHandleSingleRequest_RouteError(t *testing.T) {
 	mockR := &mockRouter{
 		routeFunc: func(ctx context.Context, method string) (*registry.ServerEntry, error) {
-			return nil, router.NewRouterError(proxy.ErrCodeMethodNotFound, "method not found", router.ErrToolNotFound)
+			return nil, router.NewRouterError(errors.ErrCodeMethodNotFound, "method not found", router.ErrToolNotFound)
 		},
 	}
 	mockGT := &mockGatewayTools{}
@@ -306,7 +307,7 @@ func TestHandleSingleRequest_RouteError(t *testing.T) {
 		t.Fatal("expected error response")
 	}
 
-	if resp.Error.Code != proxy.ErrCodeMethodNotFound {
+	if resp.Error.Code != errors.ErrCodeMethodNotFound {
 		t.Errorf("expected method not found error, got %d", resp.Error.Code)
 	}
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,34 @@
+package errors
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type JSONRPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *JSONRPCError) Error() string {
+	return fmt.Sprintf("jsonrpc: error %d: %s", e.Code, e.Message)
+}
+
+func NewJSONRPCError(code int, message string) *JSONRPCError {
+	return &JSONRPCError{
+		Code:    code,
+		Message: message,
+	}
+}
+
+const (
+	ErrCodeParseError     = -32700
+	ErrCodeInvalidRequest = -32600
+	ErrCodeMethodNotFound = -32601
+	ErrCodeInvalidParams  = -32602
+	ErrCodeInternalError = -32603
+	ErrCodeServerError   = -32000
+	ErrCodeTimeout       = -32001
+	ErrCodeUnauthorized  = -32604
+)

--- a/pkg/gateway/executor.go
+++ b/pkg/gateway/executor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
 	"github.com/mmornati/leanproxy-mcp/pkg/registry"
 	"github.com/mmornati/leanproxy-mcp/pkg/router"
@@ -40,24 +41,24 @@ func (g *gatewayTools) ListServers(ctx context.Context) ([]ServerInfo, error) {
 
 func (g *gatewayTools) InvokeTool(ctx context.Context, params InvokeToolParams) (interface{}, error) {
 	if params.ServerName == "" {
-		return nil, proxy.NewJSONRPCError(proxy.ErrCodeInvalidParams, "server_name is required")
+		return nil, errors.NewJSONRPCError(errors.ErrCodeInvalidParams, "server_name is required")
 	}
 	if params.ToolName == "" {
-		return nil, proxy.NewJSONRPCError(proxy.ErrCodeInvalidParams, "tool_name is required")
+		return nil, errors.NewJSONRPCError(errors.ErrCodeInvalidParams, "tool_name is required")
 	}
 
 	entry, err := g.serverReg.Get(ctx, params.ServerName)
 	if err != nil {
-		return nil, proxy.NewJSONRPCError(proxy.ErrCodeInvalidParams, fmt.Sprintf("server not found: %s", params.ServerName))
+		return nil, errors.NewJSONRPCError(errors.ErrCodeInvalidParams, fmt.Sprintf("server not found: %s", params.ServerName))
 	}
 
 	if entry.Health != registry.HealthHealthy && entry.Health != registry.HealthUnknown {
-		return nil, proxy.NewJSONRPCError(proxy.ErrCodeInvalidParams, fmt.Sprintf("server not running: %s", params.ServerName))
+		return nil, errors.NewJSONRPCError(errors.ErrCodeInvalidParams, fmt.Sprintf("server not running: %s", params.ServerName))
 	}
 
 	allTools, err := g.toolReg.ListTools(ctx)
 	if err != nil {
-		return nil, proxy.NewJSONRPCError(proxy.ErrCodeInternalError, "failed to list tools")
+		return nil, errors.NewJSONRPCError(errors.ErrCodeInternalError, "failed to list tools")
 	}
 
 	var foundTool *router.ToolEntry
@@ -73,12 +74,12 @@ func (g *gatewayTools) InvokeTool(ctx context.Context, params InvokeToolParams) 
 	}
 
 	if foundTool == nil {
-		return nil, proxy.NewJSONRPCError(proxy.ErrCodeInvalidParams, fmt.Sprintf("tool %s not found on server %s", params.ToolName, params.ServerName))
+		return nil, errors.NewJSONRPCError(errors.ErrCodeInvalidParams, fmt.Sprintf("tool %s not found on server %s", params.ToolName, params.ServerName))
 	}
 
 	argsJSON, err := json.Marshal(params.Arguments)
 	if err != nil {
-		return nil, proxy.NewJSONRPCError(proxy.ErrCodeInvalidParams, "invalid arguments format")
+		return nil, errors.NewJSONRPCError(errors.ErrCodeInvalidParams, "invalid arguments format")
 	}
 
 	req := proxy.JSONRPCRequest{

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 	"github.com/mmornati/leanproxy-mcp/pkg/registry"
 	"github.com/mmornati/leanproxy-mcp/pkg/router"
 )
@@ -147,12 +147,12 @@ func TestInvokeTool(t *testing.T) {
 		if err == nil {
 			t.Error("InvokeTool() expected error for missing server_name, got nil")
 		}
-		rpcErr, ok := err.(*proxy.JSONRPCError)
+		rpcErr, ok := err.(*errors.JSONRPCError)
 		if !ok {
-			t.Fatalf("InvokeTool() returned error type %T, want *proxy.JSONRPCError", err)
+			t.Fatalf("InvokeTool() returned error type %T, want *errors.JSONRPCError", err)
 		}
-		if rpcErr.Code != proxy.ErrCodeInvalidParams {
-			t.Errorf("InvokeTool() error code = %d, want %d", rpcErr.Code, proxy.ErrCodeInvalidParams)
+		if rpcErr.Code != errors.ErrCodeInvalidParams {
+			t.Errorf("InvokeTool() error code = %d, want %d", rpcErr.Code, errors.ErrCodeInvalidParams)
 		}
 	})
 
@@ -176,12 +176,12 @@ func TestInvokeTool(t *testing.T) {
 		if err == nil {
 			t.Error("InvokeTool() expected error for nonexistent server, got nil")
 		}
-		rpcErr, ok := err.(*proxy.JSONRPCError)
+		rpcErr, ok := err.(*errors.JSONRPCError)
 		if !ok {
-			t.Fatalf("InvokeTool() returned error type %T, want *proxy.JSONRPCError", err)
+			t.Fatalf("InvokeTool() returned error type %T, want *errors.JSONRPCError", err)
 		}
-		if rpcErr.Code != proxy.ErrCodeInvalidParams {
-			t.Errorf("InvokeTool() error code = %d, want %d", rpcErr.Code, proxy.ErrCodeInvalidParams)
+		if rpcErr.Code != errors.ErrCodeInvalidParams {
+			t.Errorf("InvokeTool() error code = %d, want %d", rpcErr.Code, errors.ErrCodeInvalidParams)
 		}
 	})
 

--- a/pkg/mcp/handlers_test.go
+++ b/pkg/mcp/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 	"github.com/mmornati/leanproxy-mcp/pkg/pool"
 	"github.com/mmornati/leanproxy-mcp/pkg/toolstore"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ type mockPool struct {
 
 type MockRequestResult struct {
 	Result json.RawMessage
-	Error  *pool.JSONRPCError
+	Error  *errors.JSONRPCError
 }
 
 func newMockPool() *mockPool {
@@ -101,7 +102,7 @@ func (m *mockPool) SetTools(serverName string, tools []Tool) {
 	m.tools[serverName] = tools
 }
 
-func (m *mockPool) SetRequestResult(result json.RawMessage, err *pool.JSONRPCError) {
+func (m *mockPool) SetRequestResult(result json.RawMessage, err *errors.JSONRPCError) {
 	m.requestResult = &MockRequestResult{Result: result, Error: err}
 }
 

--- a/pkg/pool/health.go
+++ b/pkg/pool/health.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 )
 
 type HealthStatus string
@@ -198,10 +200,10 @@ type PingRequest struct {
 }
 
 type PingResponse struct {
-	ID      interface{}     `json:"id"`
-	JSONRPC string          `json:"jsonrpc"`
-	Result  json.RawMessage `json:"result,omitempty"`
-	Error   *JSONRPCError   `json:"error,omitempty"`
+	ID      interface{}         `json:"id"`
+	JSONRPC string              `json:"jsonrpc"`
+	Result  json.RawMessage     `json:"result,omitempty"`
+	Error   *errors.JSONRPCError `json:"error,omitempty"`
 }
 
 func (hc *HealthChecker) performPingCheck(ctx context.Context, server *StdioServerV2) (bool, float64) {

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mmornati/leanproxy-mcp/pkg/concurrent"
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
 	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
 	"github.com/mmornati/leanproxy-mcp/pkg/registry"
@@ -48,26 +49,10 @@ func (r Request) MarshalJSON() ([]byte, error) {
 }
 
 type Response struct {
-	Result json.RawMessage `json:"result,omitempty"`
-	Error  *JSONRPCError   `json:"error,omitempty"`
-	ID     interface{}     `json:"id"`
+	Result json.RawMessage   `json:"result,omitempty"`
+	Error  *errors.JSONRPCError `json:"error,omitempty"`
+	ID     interface{}       `json:"id"`
 }
-
-type JSONRPCError struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data,omitempty"`
-}
-
-func (e *JSONRPCError) Error() string {
-	return fmt.Sprintf("jsonrpc: error %d: %s", e.Code, e.Message)
-}
-
-const (
-	ErrCodeInternalError = -32603
-	ErrCodeServerError   = -32000
-	ErrCodeTimeout       = -32001
-)
 
 type ServerState string
 

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
 	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
 	"github.com/mmornati/leanproxy-mcp/pkg/registry"
@@ -792,7 +793,7 @@ func TestPoolSendServerNotificationNotFound(t *testing.T) {
 }
 
 func TestJSONRPCError(t *testing.T) {
-	err := &JSONRPCError{
+	err := &errors.JSONRPCError{
 		Code:    -32603,
 		Message: "Internal error",
 	}
@@ -805,7 +806,7 @@ func TestJSONRPCError(t *testing.T) {
 
 func TestJSONRPCErrorWithData(t *testing.T) {
 	data := json.RawMessage(`{"key":"value"}`)
-	err := &JSONRPCError{
+	err := &errors.JSONRPCError{
 		Code:    -32000,
 		Message: "Server error",
 		Data:    data,

--- a/pkg/pool/server.go
+++ b/pkg/pool/server.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 )
 
 const (
@@ -411,7 +413,7 @@ func (s *StdioServerV2) processRequest(ctx context.Context, req Request) {
 
 	result, sendErr := s.sendRequest(ctx, req)
 	if sendErr != nil {
-		resp.Error = &JSONRPCError{Code: ErrCodeServerError, Message: sendErr.Error()}
+		resp.Error = &errors.JSONRPCError{Code: errors.ErrCodeServerError, Message: sendErr.Error()}
 		s.mu.Lock()
 		s.stats.ErrorCount++
 		s.mu.Unlock()

--- a/pkg/proxy/jit.go
+++ b/pkg/proxy/jit.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 )
 
 type JITConfig struct {
@@ -112,8 +114,8 @@ func newSuccessResponse(result interface{}, id interface{}) JSONRPCResponse {
 func newErrorResponse(err error, id interface{}) JSONRPCResponse {
 	return JSONRPCResponse{
 		JSONRPC: "2.0",
-		Error: &JSONRPCError{
-			Code:    ErrCodeInternalError,
+		Error: &errors.JSONRPCError{
+			Code:    errors.ErrCodeInternalError,
 			Message: err.Error(),
 		},
 		ID: id,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -11,6 +11,8 @@ import (
 	"net/textproto"
 	"sync"
 	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 )
 
 type SchemaCache interface {
@@ -214,33 +216,8 @@ type JSONRPCRequest struct {
 }
 
 type JSONRPCResponse struct {
-	JSONRPC string          `json:"jsonrpc"`
-	Result  json.RawMessage `json:"result,omitempty"`
-	Error   *JSONRPCError   `json:"error,omitempty"`
-	ID      interface{}     `json:"id"`
+	JSONRPC string              `json:"jsonrpc"`
+	Result  json.RawMessage     `json:"result,omitempty"`
+	Error   *errors.JSONRPCError `json:"error,omitempty"`
+	ID      interface{}         `json:"id"`
 }
-
-type JSONRPCError struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data,omitempty"`
-}
-
-func NewJSONRPCError(code int, message string) *JSONRPCError {
-	return &JSONRPCError{
-		Code:    code,
-		Message: message,
-	}
-}
-
-func (e *JSONRPCError) Error() string {
-	return fmt.Sprintf("jsonrpc: error %d: %s", e.Code, e.Message)
-}
-
-const (
-	ErrCodeParseError       = -32700
-	ErrCodeInvalidRequest   = -32600
-	ErrCodeMethodNotFound   = -32601
-	ErrCodeInvalidParams    = -32602
-	ErrCodeInternalError    = -32603
-)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 )
 
 func TestNewProxy(t *testing.T) {
@@ -292,7 +294,7 @@ func findSubstring(s, substr string) bool {
 }
 
 func TestNewJSONRPCError(t *testing.T) {
-	err := NewJSONRPCError(-32600, "Invalid Request")
+	err := errors.NewJSONRPCError(-32600, "Invalid Request")
 	if err.Code != -32600 {
 		t.Errorf("expected code -32600, got %d", err.Code)
 	}
@@ -302,7 +304,7 @@ func TestNewJSONRPCError(t *testing.T) {
 }
 
 func TestJSONRPCErrorError(t *testing.T) {
-	err := NewJSONRPCError(-32600, "Invalid Request")
+	err := errors.NewJSONRPCError(-32600, "Invalid Request")
 	expected := "jsonrpc: error -32600: Invalid Request"
 	if err.Error() != expected {
 		t.Errorf("Error() = '%s', expected '%s'", err.Error(), expected)

--- a/pkg/proxy/socket/server.go
+++ b/pkg/proxy/socket/server.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 )
 
 type jsonRPCRequest struct {
@@ -25,26 +27,11 @@ type jsonRPCRequest struct {
 }
 
 type jsonRPCResponse struct {
-	JSONRPC string          `json:"jsonrpc"`
-	Result  json.RawMessage `json:"result,omitempty"`
-	Error   *jsonRPCError   `json:"error,omitempty"`
-	ID      interface{}     `json:"id"`
+	JSONRPC string                `json:"jsonrpc"`
+	Result  json.RawMessage       `json:"result,omitempty"`
+	Error   *errors.JSONRPCError  `json:"error,omitempty"`
+	ID      interface{}          `json:"id"`
 }
-
-type jsonRPCError struct {
-	Code    int             `json:"code"`
-	Message string          `json:"message"`
-	Data    json.RawMessage `json:"data,omitempty"`
-}
-
-const (
-	ErrCodeParseError     = -32700
-	ErrCodeInvalidRequest = -32600
-	ErrCodeMethodNotFound = -32601
-	ErrCodeInvalidParams  = -32602
-	ErrCodeInternalError  = -32603
-	ErrCodeUnauthorized   = -32604
-)
 
 type MethodHandler func(ctx context.Context, params json.RawMessage) (interface{}, error)
 
@@ -176,7 +163,7 @@ func (s *Server) handleConn(conn net.Conn) {
 		}
 
 		if len(line) > int(s.config.MaxMsgSize) {
-			s.sendError(conn, nil, ErrCodeInvalidRequest, "message too large")
+			s.sendError(conn, nil, errors.ErrCodeInvalidRequest, "message too large")
 			continue
 		}
 
@@ -190,12 +177,12 @@ func (s *Server) handleRequest(conn net.Conn, data []byte, reader *bufio.Reader)
 
 	var req jsonRPCRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		s.sendError(conn, nil, ErrCodeParseError, "parse error")
+		s.sendError(conn, nil, errors.ErrCodeParseError, "parse error")
 		return
 	}
 
 	if !s.Authenticate(req.AuthToken) {
-		s.sendError(conn, req.ID, ErrCodeUnauthorized, "authentication required")
+		s.sendError(conn, req.ID, errors.ErrCodeUnauthorized, "authentication required")
 		return
 	}
 
@@ -204,13 +191,13 @@ func (s *Server) handleRequest(conn net.Conn, data []byte, reader *bufio.Reader)
 	s.mu.RUnlock()
 
 	if !ok {
-		s.sendError(conn, req.ID, ErrCodeMethodNotFound, "method not found")
+		s.sendError(conn, req.ID, errors.ErrCodeMethodNotFound, "method not found")
 		return
 	}
 
 	result, err := handler(ctx, req.Params)
 	if err != nil {
-		s.sendError(conn, req.ID, ErrCodeInternalError, err.Error())
+		s.sendError(conn, req.ID, errors.ErrCodeInternalError, err.Error())
 		return
 	}
 
@@ -231,7 +218,7 @@ func (s *Server) sendError(conn net.Conn, id interface{}, code int, message stri
 	resp := jsonRPCResponse{
 		JSONRPC: "2.0",
 		ID:      id,
-		Error: &jsonRPCError{
+		Error: &errors.JSONRPCError{
 			Code:    code,
 			Message: message,
 		},


### PR DESCRIPTION
## Summary

This PR consolidates duplicate `JSONRPCError` type definitions across multiple packages into a single shared location, implementing Story 11.3 from Epic 11: Code Quality and Error Handling.

## Changes

### New Files
- `pkg/errors/errors.go` - New shared errors package containing:
  - `JSONRPCError` struct - Consolidated JSON-RPC error type
  - Error code constants (`ErrCodeParseError`, `ErrCodeInvalidRequest`, `ErrCodeMethodNotFound`, `ErrCodeInvalidParams`, `ErrCodeInternalError`, `ErrCodeServerError`, `ErrCodeTimeout`, `ErrCodeUnauthorized`)
  - `NewJSONRPCError()` constructor function
  - `Error()` method implementation

### Updated Files
- `pkg/pool/pool.go` - Removed local JSONRPCError, now imports from `pkg/errors`
- `pkg/proxy/proxy.go` - Removed local JSONRPCError and NewJSONRPCError, now imports from `pkg/errors`
- `pkg/proxy/socket/server.go` - Removed local jsonRPCError and error code constants, now imports from `pkg/errors`
- `pkg/proxy/jit.go` - Updated to use shared errors package
- `pkg/pool/health.go` - Updated to use shared errors package
- `pkg/pool/server.go` - Updated to use shared errors package
- `pkg/gateway/executor.go` - Updated to use shared errors package
- `cmd/serve.go` - Updated to use shared errors package

### Test Files Updated
- `pkg/pool/pool_test.go`
- `pkg/proxy/proxy_test.go`
- `pkg/gateway/gateway_test.go`
- `pkg/mcp/handlers_test.go`
- `cmd/serve_test.go`

## Acceptance Criteria

- [x] JSONRPCError in single location (`pkg/errors/errors.go`)
- [x] No duplicate error type definitions
- [x] Package compiles after consolidation
- [x] All tests pass (excluding known flaky test `TestRequestWithInvalidAuthToken`)

## Related Issue

Closes #131
Part of Epic 11: Code Quality and Error Handling (#109)