### PR TITLE
Story 11.6: Parallelize sequential server tool fetching (Issue #132)

### DIFF
--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -418,69 +418,123 @@ func (h *Handler) refreshToolCacheFromServers(ctx context.Context) {
 	h.cacheRefreshes.Add(1)
 	servers := h.pool.ListServers()
 
+	if len(servers) == 0 {
+		h.logger.Debug("no servers to refresh")
+		return
+	}
+
+	type serverToolResult struct {
+		name        string
+		tools       []Tool
+		err         error
+		initErr    error
+		respError  string
+		hasResult  bool
+	}
+
+	var wg sync.WaitGroup
+	results := make(chan serverToolResult, len(servers))
+
 	for _, serverName := range servers {
-		state, _ := h.pool.GetServerState(serverName)
-		h.logger.Debug("checking server for cache refresh", "name", serverName, "state", state)
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
 
-		if state != "idle" && state != "running" && state != "busy" {
-			h.logger.Warn("server not running, attempting restart", "name", serverName, "state", state)
-			if err := h.pool.RestartServer(ctx, serverName); err != nil {
-				h.logger.Error("failed to restart server for cache", "name", serverName, "error", err)
-				h.cacheFailures.Add(1)
-				continue
+			select {
+			case <-ctx.Done():
+				results <- serverToolResult{name: name, err: ctx.Err()}
+				return
+			default:
 			}
-			time.Sleep(500 * time.Millisecond)
-		}
 
-		initErr := h.initializeServer(ctx, serverName)
-		if initErr != nil {
-			h.logger.Warn("failed to initialize server, will try without initialization", "name", serverName, "error", initErr)
-		}
+			serverCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
 
-		h.logger.Debug("requesting tools/list for cache", "name", serverName)
-		resp, err := h.pool.SendRequestToServer(ctx, serverName, MethodToolsList, nil, 10*time.Second)
-		if err != nil {
-			h.logger.Error("failed to get tools for cache", "name", serverName, "error", err)
-			h.cacheFailures.Add(1)
+			h.logger.Debug("checking server for cache refresh", "name", name)
+
+			state, _ := h.pool.GetServerState(name)
+			h.logger.Debug("server state", "name", name, "state", state)
+
+			if state != "idle" && state != "running" && state != "busy" {
+				h.logger.Warn("server not running, attempting restart", "name", name, "state", state)
+				if err := h.pool.RestartServer(serverCtx, name); err != nil {
+					h.logger.Error("failed to restart server for cache", "name", name, "error", err)
+					h.cacheFailures.Add(1)
+					results <- serverToolResult{name: name, err: err}
+					return
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
+
+			initErr := h.initializeServer(serverCtx, name)
+			if initErr != nil {
+				h.logger.Warn("failed to initialize server, will try without initialization", "name", name, "error", initErr)
+			}
+
+			h.logger.Debug("requesting tools/list for cache", "name", name)
+			resp, err := h.pool.SendRequestToServer(serverCtx, name, MethodToolsList, nil, 10*time.Second)
+			if err != nil {
+				h.logger.Error("failed to get tools for cache", "name", name, "error", err)
+				h.cacheFailures.Add(1)
+				results <- serverToolResult{name: name, err: err, initErr: initErr}
+				return
+			}
+
+			if resp != nil && resp.Error != nil {
+				h.logger.Error("server error during cache population", "name", name, "error", resp.Error.Message)
+				h.cacheFailures.Add(1)
+				results <- serverToolResult{name: name, respError: resp.Error.Message, initErr: initErr}
+				return
+			}
+
+			if resp == nil || resp.Result == nil {
+				h.logger.Error("server returned no result for cache", "name", name, "resp", fmt.Sprintf("%+v", resp))
+				h.cacheFailures.Add(1)
+				results <- serverToolResult{name: name, initErr: initErr}
+				return
+			}
+
+			if len(resp.Result) == 0 || string(resp.Result) == "null" {
+				h.logger.Error("server returned null/empty result for cache", "name", name, "resp", fmt.Sprintf("%+v", resp))
+				h.cacheFailures.Add(1)
+				results <- serverToolResult{name: name, initErr: initErr}
+				return
+			}
+
+			var toolsResult ToolsListResult
+			if err := json.Unmarshal(resp.Result, &toolsResult); err != nil {
+				h.logger.Error("failed to parse tools for cache", "name", name, "error", err, "result", string(resp.Result))
+				h.cacheFailures.Add(1)
+				results <- serverToolResult{name: name, err: err, initErr: initErr}
+				return
+			}
+
+			h.logger.Debug("caching tools from server", "name", name, "count", len(toolsResult.Tools))
+			results <- serverToolResult{name: name, tools: toolsResult.Tools, hasResult: true, initErr: initErr}
+		}(serverName)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	for result := range results {
+		if !result.hasResult {
 			continue
 		}
-
-		if resp != nil && resp.Error != nil {
-			h.logger.Error("server error during cache population", "name", serverName, "error", resp.Error.Message)
-			h.cacheFailures.Add(1)
-			continue
-		}
-
-		if resp == nil || resp.Result == nil {
-			h.logger.Error("server returned no result for cache", "name", serverName, "resp", fmt.Sprintf("%+v", resp))
-			h.cacheFailures.Add(1)
-			continue
-		}
-
-		if len(resp.Result) == 0 || string(resp.Result) == "null" {
-			h.logger.Error("server returned null/empty result for cache", "name", serverName, "resp", fmt.Sprintf("%+v", resp))
-			h.cacheFailures.Add(1)
-			continue
-		}
-
-		var toolsResult ToolsListResult
-		if err := json.Unmarshal(resp.Result, &toolsResult); err != nil {
-			h.logger.Error("failed to parse tools for cache", "name", serverName, "error", err, "result", string(resp.Result))
-			h.cacheFailures.Add(1)
-			continue
-		}
-
-		h.logger.Debug("caching tools from server", "name", serverName, "count", len(toolsResult.Tools))
 
 		h.toolCache.mu.Lock()
-		h.toolCache.tools[serverName] = toolsResult.Tools
+		h.toolCache.tools[result.name] = result.tools
 		h.toolCache.mu.Unlock()
 
 		if h.toolStore != nil {
-			if err := h.toolStore.SetTools(serverName, toolsToCachedTools(toolsResult.Tools)); err != nil {
-				h.logger.Warn("failed to persist tools to cache", "name", serverName, "error", err)
+			if err := h.toolStore.SetTools(result.name, toolsToCachedTools(result.tools)); err != nil {
+				h.logger.Warn("failed to persist tools to cache", "name", result.name, "error", err)
 			}
 		}
+
+		h.logger.Debug("cached tools from server", "name", result.name, "count", len(result.tools))
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements parallel tool fetching from MCP servers to improve performance when refreshing the tool cache from multiple servers.

## Problem

The `refreshToolCacheFromServers` function fetched tools from each server sequentially (lines 417-485 in `pkg/mcp/handlers.go`). With multiple servers, this became slow:
- Time complexity: O(n × server_timeout) where n = number of servers
- With 5 servers and 10s timeout = up to 50 seconds

## Solution

Use goroutines and `sync.WaitGroup` for parallel fetching:

- Use `sync.WaitGroup` to track all goroutines
- Each server runs in its own goroutine with its own context timeout (10 seconds)
- Results are collected via a channel to avoid race conditions
- Handle errors individually per server (don't fail all for one error)
- Respect context cancellation for early exit
- Add empty server list check at the start

## Performance Impact

| Scenario | Before | After |
|----------|--------|-------|
| 5 servers, 10s each | 50 seconds | ~10 seconds |
| 10 servers, 10s each | 100 seconds | ~10 seconds |

- Before: O(n × timeout) - sequential
- After: O(timeout) - parallel

## Implementation Details

1. **WaitGroup for tracking**: Uses `sync.WaitGroup` to track all goroutine completions
2. **Per-server context timeout**: Each goroutine has its own `context.WithTimeout` (10s)
3. **Result channel**: Uses `serverToolResult` struct to collect results safely
4. **Error handling**: Individual errors don't stop other servers from being processed
5. **Context cancellation**: Respects `ctx.Done()` for early exit

## Acceptance Criteria

- [x] Tools fetched in parallel using goroutines
- [x] WaitGroup tracks all goroutines
- [x] Errors handled individually per server
- [x] Context cancellation respected
- [x] Per-server timeout prevents long-running servers from blocking
- [x] Empty server list handled gracefully

## Testing

- All existing tests pass
- Lint passes
- Code follows existing patterns

## Documentation

The architecture documentation at `docs/architecture.md` already describes JIT Discovery and tool caching. No changes needed as this is an internal optimization.