### PR TITLE
fix(brew): correct release URLs and checksums in formula

### DIFF
--- a/Formula/leanproxy-mcp.rb
+++ b/Formula/leanproxy-mcp.rb
@@ -7,23 +7,23 @@ class LeanproxyMcp < Formula
 
   on_macos do
     on_arm do
-      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.6.0/leanproxy-mcp_v0.6.0_darwin_arm64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.6.0/leanproxy-mcp_0.6.0_darwin_arm64.tar.gz"
+      sha256 "a6b3f42665443c0fc0a4316048c057c7a5360bcd6f6f7a033ded2a77dc36c5a1"
     end
     on_intel do
-      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.6.0/leanproxy-mcp_v0.6.0_darwin_amd64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.6.0/leanproxy-mcp_0.6.0_darwin_amd64.tar.gz"
+      sha256 "5a7873b1105e2144f9302d15c2f1cc99ea4ee5d819df7e23d6dc61541e59ddc2"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.6.0/leanproxy-mcp_v0.6.0_linux_arm64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.6.0/leanproxy-mcp_0.6.0_linux_arm64.tar.gz"
+      sha256 "0eb03a81322b789f8f513809ffe32d68482d4fe1be53aef3a3d37c438ddb7bfb"
     end
     on_intel do
-      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.6.0/leanproxy-mcp_v0.6.0_linux_amd64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.6.0/leanproxy-mcp_0.6.0_linux_amd64.tar.gz"
+      sha256 "c91b1b631772b6936d4fa24079b473c8fd2bbd11a9490141952cb92759dfc9a6"
     end
   end
 


### PR DESCRIPTION
## Summary

Fix Homebrew formula `leanproxy-mcp` that was failing during installation with a 404 error for version 0.6.0.

## Problem

When users ran `brew install leanproxy-mcp`, the installation failed with:

```
Error: Failed to download resource "leanproxy-mcp (0.6.0)"
curl: (56) The requested URL returned error: 404
```

The formula was referencing incorrect release asset URLs.

## Root Cause

Two issues in `Formula/leanproxy-mcp.rb`:

1. **Incorrect asset filename**: The URL pattern used `leanproxy-mcp_v0.6.0_*.tar.gz` (with "v" prefix) but actual release assets are named `leanproxy-mcp_0.6.0_*.tar.gz` (without "v"):

   ```
   # Wrong (in formula)
   leanproxy-mcp_v0.6.0_darwin_arm64.tar.gz
   
   # Correct (in release)
   leanproxy-mcp_0.6.0_darwin_arm64.tar.gz
   ```

2. **Incorrect SHA256 checksums**: All platform URLs shared the same dummy checksum (`0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5`) instead of their actual values.

## Solution

Updated the formula with:

- Corrected URLs matching the actual release asset naming convention (`_0.6.0_` instead of `_v0.6.0_`)
- Real SHA256 checksums from `checksums.txt` in the v0.6.0 release:

  | Platform | SHA256 |
  |----------|--------|
  | darwin_arm64 | a6b3f42665443c0fc0a4316048c057c7a5360bcd6f6f7a033ded2a77dc36c5a1 |
  | darwin_amd64 | 5a7873b1105e2144f9302d15c2f1cc99ea4ee5d819df7e23d6dc61541e59ddc2 |
  | linux_arm64 | 0eb03a81322b789f8f513809ffe32d68482d4fe1be53aef3a3d37c438ddb7bfb |
  | linux_amd64 | c91b1b631772b6936d4fa24079b473c8fd2bbd11a9490141952cb92759dfc9a6 |

## Testing

Users can verify the fix by running:

```bash
brew upgrade leanproxy-mcp
# or
brew reinstall leanproxy-mcp
```

## Notes

This fix ensures consistency between the release asset naming convention and the Homebrew formula. The release workflow should be reviewed to generate assets with the `v` prefix to match the formula, or the formula should be updated for each release to match the current asset naming.

Thanks to Julien Lampin (@Xr17) for the feedback.