### PR TITLE
feat: Add OAuth2 Authentication Support for HTTP Transport

### DIFF
--- a/.github/tests/fixtures/stories/7-6-oauth-http-auth.md
+++ b/.github/tests/fixtures/stories/7-6-oauth-http-auth.md
@@ -1,0 +1,75 @@
+---
+id: 7-6
+key: oauth-http-auth
+epic: epic-7
+title: OAuth2 Authentication Support for HTTP Transport
+---
+
+# Story 7-6: OAuth2 Authentication Support for HTTP Transport
+
+## Story Header
+
+| Field | Value |
+|-------|-------|
+| **ID** | 7-6 |
+| **Key** | oauth-http-auth |
+| **Epic** | epic-7 |
+| **Title** | OAuth2 Authentication Support for HTTP Transport |
+
+## Story Requirements
+
+### User Story
+
+As a developer,
+I want to connect to OAuth2-protected MCP servers via HTTP transport,
+So that LeanProxy-MCP can authenticate to enterprise MCP servers requiring authentication.
+
+### Acceptance Criteria
+
+1. The system can configure OAuth2 authentication for HTTP transport servers in `leanproxy_servers.yaml`
+2. The HTTP client pool properly sends authentication headers when connecting to OAuth2 servers
+3. Token refresh is handled automatically by the mcp-go library
+4. Configuration supports: client_id, client_secret, scopes, auth_type (bearer, oauth2)
+5. Documentation is updated with authentication configuration examples
+
+## Developer Context
+
+### Technical Requirements
+
+- Add OAuth2 configuration to ServerConfig in `pkg/migrate/config.go`
+- Update HTTPClientPool in `pkg/pool/http_pool.go` to use OAuth when configured
+- Use `mcp-go` library's built-in OAuth support: `WithHTTPOAuth()` option
+- Support auth types: bearer (simple API key), oauth2 (full OAuth2 flow)
+
+### Configuration Schema
+
+```yaml
+servers:
+  - name: my-oauth-server
+    transport: http
+    http:
+      url: https://api.example.com/mcp
+      auth:
+        type: oauth2           # bearer | oauth2
+        client_id: "my-client"
+        client_secret: "secret"
+        scopes:
+          - mcp:read
+          - mcp:write
+```
+
+### Files to Modify
+
+1. `pkg/migrate/config.go` - Add AuthConfig struct
+2. `pkg/pool/http_pool.go` - Add OAuth support in HTTPClientServer
+3. `docs/configuration.md` - Add authentication documentation
+
+## Implementation Checklist
+
+- [ ] Add AuthConfig struct to pkg/migrate/config.go
+- [ ] Update HTTPClientServer to support OAuth config
+- [ ] Add WithHTTPOAuth option when creating mcp-go client
+- [ ] Update docs/configuration.md with auth examples
+- [ ] Add unit tests for OAuth config parsing
+- [ ] Verify tests pass
+- [ ] Run lint and typecheck

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,9 +70,38 @@ servers:
       headers:
         Authorization: Bearer ghp_yourPersonalAccessToken
         Content-Type: application/json
+      auth:
+        type: bearer
+        client_secret: ghp_yourPersonalAccessToken
     timeout: 30s
     connect_timeout: 10s
 ```
+
+##### HTTP Transport with OAuth2 Authentication
+
+```yaml
+servers:
+  - name: enterprise-mcp
+    enabled: true
+    transport: http
+    http:
+      url: https://api.enterprise.com/mcp
+      auth:
+        type: oauth2
+        client_id: my-client-id
+        client_secret: my-client-secret
+        scopes:
+          - mcp:read
+          - mcp:write
+    timeout: 60s
+```
+
+#### Auth Types
+
+| Type | Description |
+|------|-------------|
+| `bearer` | Simple API key in Authorization header |
+| `oauth2` | Full OAuth 2.0 flow with automatic token refresh |
 
 ##### SSE Transport Example
 

--- a/pkg/migrate/config.go
+++ b/pkg/migrate/config.go
@@ -36,6 +36,15 @@ type StdioConfig struct {
 type HTTPConfig struct {
 	URL     string            `yaml:"url"`
 	Headers map[string]string `yaml:"headers"`
+	Auth    *AuthConfig      `yaml:"auth,omitempty"`
+}
+
+type AuthConfig struct {
+	Type          string   `yaml:"type"`           // bearer, oauth2
+	ClientID      string   `yaml:"client_id"`
+	ClientSecret string   `yaml:"client_secret"`
+	Scopes       []string `yaml:"scopes"`
+	TokenURL     string   `yaml:"token_url"`       // optional, for bearer token exchange
 }
 
 type ServerConfig struct {

--- a/pkg/migrate/config_test.go
+++ b/pkg/migrate/config_test.go
@@ -61,6 +61,13 @@ servers:
       url: http://localhost:8080
       headers:
         Authorization: Bearer token123
+      auth:
+        type: oauth2
+        client_id: my-client-id
+        client_secret: my-secret
+        scopes:
+          - mcp:read
+          - mcp:write
     timeout: 60s
     connect_timeout: 5s
     cache_settings:
@@ -101,6 +108,21 @@ servers:
 	}
 	if server.HTTP.Headers["Authorization"] != "Bearer token123" {
 		t.Errorf("Authorization header = %v, want Bearer token123", server.HTTP.Headers["Authorization"])
+	}
+	if server.HTTP.Auth == nil {
+		t.Fatal("HTTP.Auth should not be nil")
+	}
+	if server.HTTP.Auth.Type != "oauth2" {
+		t.Errorf("Auth.Type = %v, want oauth2", server.HTTP.Auth.Type)
+	}
+	if server.HTTP.Auth.ClientID != "my-client-id" {
+		t.Errorf("Auth.ClientID = %v, want my-client-id", server.HTTP.Auth.ClientID)
+	}
+	if server.HTTP.Auth.ClientSecret != "my-secret" {
+		t.Errorf("Auth.ClientSecret = %v, want my-secret", server.HTTP.Auth.ClientSecret)
+	}
+	if len(server.HTTP.Auth.Scopes) != 2 || server.HTTP.Auth.Scopes[0] != "mcp:read" {
+		t.Errorf("Auth.Scopes = %v, want [mcp:read mcp:write]", server.HTTP.Auth.Scopes)
 	}
 	if server.TimeoutValue != 60*1e9 {
 		t.Errorf("TimeoutValue = %v, want 60s", server.TimeoutValue)
@@ -332,6 +354,40 @@ servers:
 	}
 	if cfg.Servers[0].Transport != registry.TransportSSE {
 		t.Errorf("Transport = %v, want sse", cfg.Servers[0].Transport)
+	}
+}
+
+func TestLoadConfigBearerAuth(t *testing.T) {
+	yamlContent := `
+servers:
+  - name: bearer-server
+    transport: http
+    http:
+      url: http://localhost:8080
+      auth:
+        type: bearer
+        client_secret: my-api-key
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "leanproxy_servers.yaml")
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("WriteFile() failed: %v", err)
+	}
+
+	ctx := context.Background()
+	cfg, err := LoadConfig(ctx, configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() failed: %v", err)
+	}
+	server := cfg.Servers[0]
+	if server.HTTP.Auth == nil {
+		t.Fatal("HTTP.Auth should not be nil")
+	}
+	if server.HTTP.Auth.Type != "bearer" {
+		t.Errorf("Auth.Type = %v, want bearer", server.HTTP.Auth.Type)
+	}
+	if server.HTTP.Auth.ClientSecret != "my-api-key" {
+		t.Errorf("Auth.ClientSecret = %v, want my-api-key", server.HTTP.Auth.ClientSecret)
 	}
 }
 

--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -24,6 +24,7 @@ type HTTPClientServer struct {
 	logger    *slog.Logger
 	initOnce  sync.Once
 	initErr   error
+	oauthOpts []transport.StreamableHTTPCOption
 }
 
 func NewHTTPClientServer(name string, config *migrate.ServerConfig, logger *slog.Logger) *HTTPClientServer {
@@ -31,11 +32,30 @@ func NewHTTPClientServer(name string, config *migrate.ServerConfig, logger *slog
 		logger = slog.Default()
 	}
 
+	var oauthOpts []transport.StreamableHTTPCOption
+	if config.HTTP != nil && config.HTTP.Auth != nil {
+		authCfg := config.HTTP.Auth
+		switch authCfg.Type {
+		case "bearer":
+			oauthOpts = append(oauthOpts, transport.WithHTTPHeaders(map[string]string{
+				"Authorization": "Bearer " + authCfg.ClientSecret,
+			}))
+		case "oauth2":
+			oauthCfg := transport.OAuthConfig{
+				ClientID:     authCfg.ClientID,
+				ClientSecret: authCfg.ClientSecret,
+				Scopes:       authCfg.Scopes,
+			}
+			oauthOpts = append(oauthOpts, transport.WithHTTPOAuth(oauthCfg))
+		}
+	}
+
 	return &HTTPClientServer{
-		name:   name,
-		config: config,
-		state:  StateStarting,
-		logger: logger,
+		name:     name,
+		config:   config,
+		state:   StateStarting,
+		logger:  logger,
+		oauthOpts: oauthOpts,
 	}
 }
 
@@ -63,7 +83,10 @@ func (s *HTTPClientServer) Initialize(ctx context.Context) error {
 			}
 		}
 
-		c, err := client.NewStreamableHttpClient(baseURL, transport.WithHTTPHeaders(headers))
+		opts := []transport.StreamableHTTPCOption{transport.WithHTTPHeaders(headers)}
+		opts = append(opts, s.oauthOpts...)
+
+		c, err := client.NewStreamableHttpClient(baseURL, opts...)
 		if err != nil {
 			s.initErr = fmt.Errorf("http_pool: create client: %w", err)
 			s.setState(StateError)

--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,18 +36,32 @@ func NewHTTPClientServer(name string, config *migrate.ServerConfig, logger *slog
 	var oauthOpts []transport.StreamableHTTPCOption
 	if config.HTTP != nil && config.HTTP.Auth != nil {
 		authCfg := config.HTTP.Auth
-		switch authCfg.Type {
+		authType := strings.ToLower(strings.TrimSpace(authCfg.Type))
+
+		switch authType {
 		case "bearer":
+			if authCfg.ClientSecret == "" {
+				logger.Warn("http_pool: bearer auth configured but client_secret is empty", "server", name)
+				break
+			}
 			oauthOpts = append(oauthOpts, transport.WithHTTPHeaders(map[string]string{
 				"Authorization": "Bearer " + authCfg.ClientSecret,
 			}))
 		case "oauth2":
+			if authCfg.ClientID == "" || authCfg.ClientSecret == "" {
+				logger.Warn("http_pool: oauth2 auth configured but client_id or client_secret is empty", "server", name)
+				break
+			}
 			oauthCfg := transport.OAuthConfig{
 				ClientID:     authCfg.ClientID,
 				ClientSecret: authCfg.ClientSecret,
 				Scopes:       authCfg.Scopes,
 			}
 			oauthOpts = append(oauthOpts, transport.WithHTTPOAuth(oauthCfg))
+		default:
+			if authType != "" {
+				logger.Warn("http_pool: unknown auth type, skipping authentication", "server", name, "auth_type", authCfg.Type)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Implements OAuth2 authentication support for HTTP transport servers, allowing LeanProxy-MCP to connect to MCP servers requiring authentication.

## Changes

### Configuration (`pkg/migrate/config.go`)
- Added `AuthConfig` struct with fields: `Type`, `ClientID`, `ClientSecret`, `Scopes`, `TokenURL`
- Supports auth types: `bearer` (simple API key), `oauth2` (full OAuth 2.0 flow)

### HTTP Pool (`pkg/pool/http_pool.go`)
- Updated `HTTPClientServer` to accept OAuth options
- Uses mcp-go library's built-in `WithHTTPOAuth()` option for OAuth2 flow
- Handles bearer token authentication via headers

### Tests (`pkg/migrate/config_test.go`)
- Added `TestLoadConfigFull` to verify OAuth config parsing
- Added `TestLoadConfigBearerAuth` to verify bearer auth config

### Documentation (`docs/quickstart.md`)
- Added HTTP transport examples with `bearer` and `oauth2` auth types
- Added auth types reference table

## Configuration Examples

### Bearer Token (Simple API Key)
```yaml
servers:
  - name: github
    transport: http
    http:
      url: https://api.github.com/mcp
      auth:
        type: bearer
        client_secret: ghp_yourToken
```

### OAuth 2.0 (Full Flow)
```yaml
servers:
  - name: enterprise-mcp
    transport: http
    http:
      url: https://api.enterprise.com/mcp
      auth:
        type: oauth2
        client_id: my-client-id
        client_secret: my-client-secret
        scopes:
          - mcp:read
          - mcp:write
```

## Technical Details

- Uses `mcp-go` v0.50.0's built-in OAuth support
- `WithHTTPOAuth()` enables automatic token refresh
- Bearer auth sends `Authorization: Bearer <token>` header
- OAuth2 flow handles 401 responses and token exchange automatically

## Testing

- Unit tests pass for config parsing
- Binary builds successfully
- Manual testing with OAuth2-protected MCP server recommended

---
**Related Issue:** N/A (feature request from product discussion)
**Story:** 7-6-oauth-http-auth