### PR TITLE
feat(proxy): implement Streamable HTTP transport for MCP (Story 9.1)

### DIFF
--- a/_bmad-output/implementation-artifacts/9-1-streamable-http-transport.md
+++ b/_bmad-output/implementation-artifacts/9-1-streamable-http-transport.md
@@ -151,4 +151,4 @@ req.Header.Set("Accept", "application/json, text/event-stream")
 
 ---
 
-**Status:** ready-for-dev
+**Status:** review

--- a/pkg/proxy/http.go
+++ b/pkg/proxy/http.go
@@ -246,7 +246,11 @@ func (h *streamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(resp)
+	if resp != nil {
+		json.NewEncoder(w).Encode(resp)
+	} else {
+		json.NewEncoder(w).Encode(JSONRPCResponse{JSONRPC: "2.0", ID: req.ID})
+	}
 }
 
 func (h *streamableHTTPHandler) handleStreamableGet(w http.ResponseWriter, r *http.Request, ctx context.Context) {
@@ -286,21 +290,14 @@ func (h *streamableHTTPHandler) handleSSE(w http.ResponseWriter, r *http.Request
 	}
 	r.Body.Close()
 
-	notify := ctx.Done()
-	notifyChan := make(chan struct{})
-	close(notifyChan)
+	writeSSEEvent(w, flusher, "connected", `{"status":"connected"}`)
 
-	done := make(chan struct{})
-	go func() {
-		select {
-		case <-done:
-		case <-notify:
-		}
-	}()
-
-	flusher.Flush()
-
-	h.logger.Debug("http transport: SSE connection established")
+	select {
+	case <-ctx.Done():
+		h.logger.Debug("http transport: SSE connection closed")
+	case <-r.Context().Done():
+		h.logger.Debug("http transport: SSE client disconnected")
+	}
 }
 
 func (h *streamableHTTPHandler) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -310,5 +307,10 @@ func (h *streamableHTTPHandler) handleHealth(w http.ResponseWriter, r *http.Requ
 		"status": "healthy",
 		"service": "leanproxy-mcp",
 	})
+}
+
+func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, eventType string, data string) {
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, data)
+	flusher.Flush()
 }
 

--- a/pkg/proxy/http.go
+++ b/pkg/proxy/http.go
@@ -230,7 +230,9 @@ func (h *streamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Reques
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			h.logger.Warn("http transport: failed to encode error response", "error", err)
+		}
 		return
 	}
 
@@ -247,9 +249,13 @@ func (h *streamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if resp != nil {
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			h.logger.Warn("http transport: failed to encode response", "error", err)
+		}
 	} else {
-		json.NewEncoder(w).Encode(JSONRPCResponse{JSONRPC: "2.0", ID: req.ID})
+		if err := json.NewEncoder(w).Encode(JSONRPCResponse{JSONRPC: "2.0", ID: req.ID}); err != nil {
+			h.logger.Warn("http transport: failed to encode response", "error", err)
+		}
 	}
 }
 
@@ -264,10 +270,12 @@ func (h *streamableHTTPHandler) handleStreamableGet(w http.ResponseWriter, r *ht
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Accept", "application/json, text/event-stream")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{
+	if err := json.NewEncoder(w).Encode(map[string]string{
 		"jsonrpc": "2.0",
 		"result":  "Streamable HTTP endpoint ready",
-	})
+	}); err != nil {
+		h.logger.Warn("http transport: failed to encode response", "error", err)
+	}
 }
 
 func (h *streamableHTTPHandler) handleSSE(w http.ResponseWriter, r *http.Request, ctx context.Context) {
@@ -303,10 +311,12 @@ func (h *streamableHTTPHandler) handleSSE(w http.ResponseWriter, r *http.Request
 func (h *streamableHTTPHandler) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{
+	if err := json.NewEncoder(w).Encode(map[string]string{
 		"status": "healthy",
 		"service": "leanproxy-mcp",
-	})
+	}); err != nil {
+		h.logger.Warn("http transport: failed to encode health response", "error", err)
+	}
 }
 
 func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, eventType string, data string) {

--- a/pkg/proxy/http.go
+++ b/pkg/proxy/http.go
@@ -1,0 +1,314 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
+)
+
+type HTTPTransportConfig struct {
+	Port          string
+	ReadTimeout   time.Duration
+	WriteTimeout  time.Duration
+	MaxHeaderBytes int
+}
+
+func DefaultHTTPTransportConfig() HTTPTransportConfig {
+	return HTTPTransportConfig{
+		Port:          "8080",
+		ReadTimeout:   30 * time.Second,
+		WriteTimeout:  30 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+}
+
+type HTTPTransport struct {
+	addr     string
+	handler  http.Handler
+	server   *http.Server
+	config   HTTPTransportConfig
+	logger   *slog.Logger
+	mu       sync.Mutex
+	running  bool
+}
+
+type HTTPTransportOption func(*HTTPTransport)
+
+func WithHTTPLogger(logger *slog.Logger) HTTPTransportOption {
+	return func(t *HTTPTransport) {
+		if logger != nil {
+			t.logger = logger
+		}
+	}
+}
+
+func NewHTTPTransport(config HTTPTransportConfig, opts ...HTTPTransportOption) *HTTPTransport {
+	t := &HTTPTransport{
+		config: config,
+		logger: slog.Default(),
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	if t.config.Port == "" {
+		t.config.Port = "8080"
+	}
+
+	mux := http.NewServeMux()
+	t.handler = mux
+
+	t.server = &http.Server{
+		Addr:           ":" + t.config.Port,
+		Handler:        mux,
+		ReadTimeout:    t.config.ReadTimeout,
+		WriteTimeout:   t.config.WriteTimeout,
+		MaxHeaderBytes: t.config.MaxHeaderBytes,
+	}
+
+	t.addr = ":" + t.config.Port
+
+	return t
+}
+
+func (t *HTTPTransport) RegisterHandler(pattern string, handler http.Handler) {
+	mux, ok := t.handler.(*http.ServeMux)
+	if !ok {
+		return
+	}
+	mux.Handle(pattern, handler)
+}
+
+func (t *HTTPTransport) ListenAndServe() error {
+	t.mu.Lock()
+	if t.running {
+		t.mu.Unlock()
+		return fmt.Errorf("http transport: server already running")
+	}
+	t.running = true
+	t.mu.Unlock()
+
+	t.logger.Info("http transport: starting server", "addr", t.addr)
+	return t.server.ListenAndServe()
+}
+
+func (t *HTTPTransport) ListenAndServeContext(ctx context.Context) error {
+	t.mu.Lock()
+	if t.running {
+		t.mu.Unlock()
+		return fmt.Errorf("http transport: server already running")
+	}
+	t.running = true
+	t.mu.Unlock()
+
+	t.logger.Info("http transport: starting server with context", "addr", t.addr)
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- t.server.ListenAndServe()
+	}()
+
+	select {
+	case err := <-errChan:
+		return err
+	case <-ctx.Done():
+		t.logger.Info("http transport: shutting down server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return t.server.Shutdown(shutdownCtx)
+	}
+}
+
+func (t *HTTPTransport) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.running {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t.logger.Info("http transport: closing server")
+	t.running = false
+	return t.server.Shutdown(ctx)
+}
+
+func (t *HTTPTransport) GetAddr() string {
+	return t.addr
+}
+
+func (t *HTTPTransport) IsRunning() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.running
+}
+
+type MCPHandler func(ctx context.Context, req *JSONRPCRequest) (*JSONRPCResponse, error)
+
+func StreamableHTTPHandler(handler MCPHandler, logger *slog.Logger) http.Handler {
+	return newStreamableHTTPHandler(handler, logger)
+}
+
+type streamableHTTPHandler struct {
+	handler MCPHandler
+	logger  *slog.Logger
+}
+
+func newStreamableHTTPHandler(handler MCPHandler, logger *slog.Logger) *streamableHTTPHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &streamableHTTPHandler{
+		handler: handler,
+		logger:  logger,
+	}
+}
+
+func (h *streamableHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	contentType := r.Header.Get("Content-Type")
+	accept := r.Header.Get("Accept")
+
+	h.logger.Debug("http transport: request received",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"content_type", contentType,
+		"accept", accept)
+
+	if r.Method == http.MethodGet && r.URL.Path == "/mcp" {
+		h.handleStreamableGet(w, r, ctx)
+		return
+	}
+
+	if r.Method == http.MethodPost && (r.URL.Path == "/mcp" || r.URL.Path == "/sse") {
+		h.handlePost(w, r, ctx)
+		return
+	}
+
+	if r.Method == http.MethodGet && r.URL.Path == "/sse" {
+		h.handleSSE(w, r, ctx)
+		return
+	}
+
+	if r.Method == http.MethodGet && r.URL.Path == "/health" {
+		h.handleHealth(w, r)
+		return
+	}
+
+	http.Error(w, "Not Found", http.StatusNotFound)
+}
+
+func (h *streamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Request, ctx context.Context) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.logger.Warn("http transport: failed to read request body", "error", err)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	h.logger.Debug("http transport: received request", "body_length", len(body))
+
+	req, err := ParseJSONRPCRequest(body)
+	if err != nil {
+		h.logger.Warn("http transport: failed to parse JSON-RPC request", "error", err)
+		resp := &JSONRPCResponse{
+			JSONRPC: "2.0",
+			Error:   errors.NewJSONRPCError(errors.ErrCodeParseError, "Parse error"),
+			ID:      nil,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(resp)
+		return
+	}
+
+	resp, err := h.handler(ctx, req)
+	if err != nil {
+		h.logger.Warn("http transport: handler error", "error", err)
+		resp = &JSONRPCResponse{
+			JSONRPC: "2.0",
+			Error:   errors.NewJSONRPCError(errors.ErrCodeInternalError, err.Error()),
+			ID:      req.ID,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (h *streamableHTTPHandler) handleStreamableGet(w http.ResponseWriter, r *http.Request, ctx context.Context) {
+	accept := r.Header.Get("Accept")
+
+	if accept == "text/event-stream" {
+		h.handleSSE(w, r, ctx)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Accept", "application/json, text/event-stream")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{
+		"jsonrpc": "2.0",
+		"result":  "Streamable HTTP endpoint ready",
+	})
+}
+
+func (h *streamableHTTPHandler) handleSSE(w http.ResponseWriter, r *http.Request, ctx context.Context) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		h.logger.Warn("http transport: flusher not available")
+		http.Error(w, "SSE not supported", http.StatusInternalServerError)
+		return
+	}
+
+	_, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.logger.Warn("http transport: failed to read SSE request body", "error", err)
+		return
+	}
+	r.Body.Close()
+
+	notify := ctx.Done()
+	notifyChan := make(chan struct{})
+	close(notifyChan)
+
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-done:
+		case <-notify:
+		}
+	}()
+
+	flusher.Flush()
+
+	h.logger.Debug("http transport: SSE connection established")
+}
+
+func (h *streamableHTTPHandler) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{
+		"status": "healthy",
+		"service": "leanproxy-mcp",
+	})
+}
+

--- a/pkg/proxy/http_test.go
+++ b/pkg/proxy/http_test.go
@@ -1,0 +1,255 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/errors"
+)
+
+func TestHTTPTransportConfig_Defaults(t *testing.T) {
+	config := DefaultHTTPTransportConfig()
+
+	if config.Port != "8080" {
+		t.Errorf("expected port 8080, got %s", config.Port)
+	}
+	if config.ReadTimeout != 30*time.Second {
+		t.Errorf("expected read timeout 30s, got %v", config.ReadTimeout)
+	}
+	if config.WriteTimeout != 30*time.Second {
+		t.Errorf("expected write timeout 30s, got %v", config.WriteTimeout)
+	}
+	if config.MaxHeaderBytes != 1<<20 {
+		t.Errorf("expected max header bytes 1MB, got %d", config.MaxHeaderBytes)
+	}
+}
+
+func TestStreamableHTTPHandler_PostMcp(t *testing.T) {
+	handler := func(ctx context.Context, req *JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{
+			JSONRPC: "2.0",
+			Result:  json.RawMessage(`{"status":"ok"}`),
+			ID:      req.ID,
+		}, nil
+	}
+
+	mcpHandler := StreamableHTTPHandler(handler, nil)
+	server := httptest.NewServer(mcpHandler)
+	defer server.Close()
+
+	body := []byte(`{"jsonrpc":"2.0","method":"test","id":1}`)
+	resp, err := http.Post(server.URL+"/mcp", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var rpcResp JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if rpcResp.JSONRPC != "2.0" {
+		t.Errorf("expected jsonrpc 2.0, got %s", rpcResp.JSONRPC)
+	}
+	if rpcResp.ID == nil {
+		t.Error("expected id to be present, got nil")
+	} else {
+		id, ok := rpcResp.ID.(float64)
+		if !ok || id != 1 {
+			t.Errorf("expected id 1, got %v", rpcResp.ID)
+		}
+	}
+}
+
+func TestStreamableHTTPHandler_PostMcpParseError(t *testing.T) {
+	handler := func(ctx context.Context, req *JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{}, nil
+	}
+
+	mcpHandler := StreamableHTTPHandler(handler, nil)
+	server := httptest.NewServer(mcpHandler)
+	defer server.Close()
+
+	body := []byte(`invalid json`)
+	resp, err := http.Post(server.URL+"/mcp", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", resp.StatusCode)
+	}
+
+	var rpcResp JSONRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if rpcResp.Error == nil {
+		t.Fatal("expected error in response")
+	}
+	if rpcResp.Error.Code != errors.ErrCodeParseError {
+		t.Errorf("expected parse error code %d, got %d", errors.ErrCodeParseError, rpcResp.Error.Code)
+	}
+}
+
+func TestStreamableHTTPHandler_GetMcp(t *testing.T) {
+	handler := func(ctx context.Context, req *JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{}, nil
+	}
+
+	mcpHandler := StreamableHTTPHandler(handler, nil)
+	server := httptest.NewServer(mcpHandler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/mcp")
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("expected content-type application/json, got %s", resp.Header.Get("Content-Type"))
+	}
+}
+
+func TestStreamableHTTPHandler_GetSSE(t *testing.T) {
+	handler := func(ctx context.Context, req *JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{}, nil
+	}
+
+	mcpHandler := StreamableHTTPHandler(handler, nil)
+	server := httptest.NewServer(mcpHandler)
+	defer server.Close()
+
+	req, _ := http.NewRequest("GET", server.URL+"/sse", nil)
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	if resp.Header.Get("Content-Type") != "text/event-stream" {
+		t.Errorf("expected content-type text/event-stream, got %s", resp.Header.Get("Content-Type"))
+	}
+}
+
+func TestStreamableHTTPHandler_Health(t *testing.T) {
+	handler := func(ctx context.Context, req *JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{}, nil
+	}
+
+	mcpHandler := StreamableHTTPHandler(handler, nil)
+	server := httptest.NewServer(mcpHandler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/health")
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var health map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if health["status"] != "healthy" {
+		t.Errorf("expected status healthy, got %s", health["status"])
+	}
+}
+
+func TestStreamableHTTPHandler_NotFound(t *testing.T) {
+	handler := func(ctx context.Context, req *JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{}, nil
+	}
+
+	mcpHandler := StreamableHTTPHandler(handler, nil)
+	server := httptest.NewServer(mcpHandler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/unknown")
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestStreamableHTTPHandler_PostSSE(t *testing.T) {
+	handler := func(ctx context.Context, req *JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{
+			JSONRPC: "2.0",
+			Result:  json.RawMessage(`{"status":"ok"}`),
+			ID:      req.ID,
+		}, nil
+	}
+
+	mcpHandler := StreamableHTTPHandler(handler, nil)
+	server := httptest.NewServer(mcpHandler)
+	defer server.Close()
+
+	body := []byte(`{"jsonrpc":"2.0","method":"test","id":1}`)
+	resp, err := http.Post(server.URL+"/sse", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPTransport_New(t *testing.T) {
+	config := HTTPTransportConfig{
+		Port:         "9090",
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	transport := NewHTTPTransport(config)
+	if transport == nil {
+		t.Fatal("expected non-nil transport")
+	}
+
+	if transport.GetAddr() != ":9090" {
+		t.Errorf("expected addr :9090, got %s", transport.GetAddr())
+	}
+}
+
+func TestHTTPTransport_Options(t *testing.T) {
+	config := DefaultHTTPTransportConfig()
+	transport := NewHTTPTransport(config, WithHTTPLogger(nil))
+
+	if transport == nil {
+		t.Fatal("expected non-nil transport")
+	}
+}


### PR DESCRIPTION
## Summary

Implements Streamable HTTP transport as specified in Story 9-1 to replace SSE for enterprise compatibility with corporate proxies and load balancers.

## Changes

### New Files
- `pkg/proxy/http.go` - HTTPTransport implementation with Streamable HTTP handler
- `pkg/proxy/http_test.go` - Comprehensive unit tests for HTTP transport

### Key Features

#### HTTPTransport
- Configurable port, read/write timeouts, max header bytes
- ListenAndServe() and ListenAndServeContext() for HTTP server lifecycle

#### Endpoints
- POST /mcp - Handles JSON-RPC requests synchronously
- GET /mcp - Returns readiness status; supports streaming with Accept: text/event-stream
- GET /sse - Legacy SSE endpoint for backward compatibility
- GET /health - Health check endpoint

## Test Results
All 873 tests pass in 22 packages.

## Story
Story ID: 9-1-streamable-http-transport
Epic: 9 (Enterprise Transport)