### PR TITLE
fix(brew): correct archive URLs and checksums in Homebrew formula

### DIFF
--- a/.github/workflows/homebrew-formula-update.yml
+++ b/.github/workflows/homebrew-formula-update.yml
@@ -44,7 +44,7 @@ jobs:
 
           for arch in amd64 arm64; do
             for os in darwin linux; do
-              url="https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_v${VERSION}_${os}_${arch}.tar.gz"
+              url="https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_${VERSION}_${os}_${arch}.tar.gz"
               echo "Downloading $url..."
               curl -sL "$url" -o /tmp/archive.tar.gz
               sha=$(sha256sum /tmp/archive.tar.gz | cut -d' ' -f1)
@@ -72,22 +72,22 @@ jobs:
 
             on_macos do
               on_arm do
-                url "https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_v${VERSION}_darwin_arm64.tar.gz"
+                url "https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_${VERSION}_darwin_arm64.tar.gz"
                 sha256 "${SHA_DARWIN_ARM64}"
               end
               on_intel do
-                url "https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_v${VERSION}_darwin_amd64.tar.gz"
+                url "https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_${VERSION}_darwin_amd64.tar.gz"
                 sha256 "${SHA_DARWIN_AMD64}"
               end
             end
 
             on_linux do
               on_arm do
-                url "https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_v${VERSION}_linux_arm64.tar.gz"
+                url "https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_${VERSION}_linux_arm64.tar.gz"
                 sha256 "${SHA_LINUX_ARM64}"
               end
               on_intel do
-                url "https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_v${VERSION}_linux_amd64.tar.gz"
+                url "https://github.com/mmornati/leanproxy-mcp/releases/download/v${VERSION}/leanproxy-mcp_${VERSION}_linux_amd64.tar.gz"
                 sha256 "${SHA_LINUX_AMD64}"
               end
             end

--- a/Formula/leanproxy-mcp.rb
+++ b/Formula/leanproxy-mcp.rb
@@ -7,23 +7,23 @@ class LeanproxyMcp < Formula
 
   on_macos do
     on_arm do
-      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.7.0/leanproxy-mcp_v0.7.0_darwin_arm64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.7.0/leanproxy-mcp_0.7.0_darwin_arm64.tar.gz"
+      sha256 "91b2a5a8a0c1674e204034dd44cf545b37b6d51eab446958ad420ff7582cb8ea"
     end
     on_intel do
-      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.7.0/leanproxy-mcp_v0.7.0_darwin_amd64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.7.0/leanproxy-mcp_0.7.0_darwin_amd64.tar.gz"
+      sha256 "83f754b583492174bb28530eb685a4c86902d4c863a29d9b09e2e25ef7c5f089"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.7.0/leanproxy-mcp_v0.7.0_linux_arm64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.7.0/leanproxy-mcp_0.7.0_linux_arm64.tar.gz"
+      sha256 "21cbd1c1e89634a0851430635acaa2cced0079d19bf8888d48c23f0b241d7430"
     end
     on_intel do
-      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.7.0/leanproxy-mcp_v0.7.0_linux_amd64.tar.gz"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      url "https://github.com/mmornati/leanproxy-mcp/releases/download/v0.7.0/leanproxy-mcp_0.7.0_linux_amd64.tar.gz"
+      sha256 "a8a2763ccc6e5a096ef3720e0265ae16d2d1e1becdcb5d74f0da644f112c7a8a"
     end
   end
 


### PR DESCRIPTION
## Description

Fixes #195 — the Homebrew formula file (`Formula/leanproxy-mcp.rb`) contained incorrect archive URLs and SHA256 checksums, causing `brew install leanproxy-mcp` to fail.

## Root Cause

Two issues were identified:

### 1. Wrong archive filename pattern (both formula + CI workflow)

GoReleaser (`.goreleaser.yml`) uses the default archive naming template:

```
{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.tar.gz
```

In GoReleaser, `{{ .Version }}` is the git tag **without** the `v` prefix. For tag `v0.7.0`, the version resolves to `0.7.0`, producing archives like:

- `leanproxy-mcp_0.7.0_darwin_arm64.tar.gz`
- `leanproxy-mcp_0.7.0_darwin_amd64.tar.gz`

But the formula used `leanproxy-mcp_v0.7.0_...` (with a `v` prefix before the version in the filename), referencing non-existent files:

- `leanproxy-mcp_v0.7.0_darwin_arm64.tar.gz` (404)
- `leanproxy-mcp_v0.7.0_darwin_amd64.tar.gz` (404)

The same bug existed in `.github/workflows/homebrew-formula-update.yml` — the CI workflow that auto-generates the formula on each release used the same incorrect `leanproxy-mcp_v${VERSION}` pattern in both the download step and the generated template.

### 2. Placeholder SHA256 checksums

All four platform checksums in the formula were set to the same placeholder value (`0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5`) instead of the actual per-platform SHA256 hashes from the v0.7.0 release.

## Changes Made

### `Formula/leanproxy-mcp.rb`
- Fixed all four archive URLs to use `leanproxy-mcp_0.7.0_...` (no `v` prefix)
- Updated SHA256 checksums to the correct values from the v0.7.0 release artifacts:
  - `darwin/arm64`: `91b2a5a8a0c1674e204034dd44cf545b37b6d51eab446958ad420ff7582cb8ea`
  - `darwin/amd64`: `83f754b583492174bb28530eb685a4c86902d4c863a29d9b09e2e25ef7c5f089`
  - `linux/arm64`: `21cbd1c1e89634a0851430635acaa2cced0079d19bf8888d48c23f0b241d7430`
  - `linux/amd64`: `a8a2763ccc6e5a096ef3720e0265ae16d2d1e1becdcb5d74f0da644f112c7a8a`

### `.github/workflows/homebrew-formula-update.yml`
- Fixed the download URL in the SHA256 computation step: `leanproxy-mcp_v${VERSION}` → `leanproxy-mcp_${VERSION}`
- Fixed the archive URL pattern in the generated formula template: `leanproxy-mcp_v${VERSION}` → `leanproxy-mcp_${VERSION}`
- This ensures future releases will produce correct formulas automatically

## Verification

The corrected URLs and checksums were verified against the actual release artifacts published for [v0.7.0](https://github.com/mmornati/leanproxy-mcp/releases/tag/v0.7.0).

The formula can now be tested locally with:
```bash
brew tap mmornati/leanproxy-mcp https://github.com/mmornati/leanproxy-mcp
brew install leanproxy-mcp
```