### PR TITLE
fix: perform MCP initialize handshake before forwarding tools/call to backend servers

### DIFF
--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -243,7 +243,7 @@ func (h *Handler) initializeServer(ctx context.Context, serverName string) error
 
 	h.logger.Debug("sending initialize request", "name", serverName, "params", string(paramsBytes))
 
-	resp, err := h.pool.SendRequestToServerWithID(ctx, serverName, MethodInitialize, paramsBytes, 10*time.Second, 1)
+	resp, err := h.pool.SendRequestToServerWithID(ctx, serverName, MethodInitialize, paramsBytes, 120*time.Second, 1)
 	if err != nil {
 		h.logger.Error("initialize request failed", "name", serverName, "error", err)
 		return fmt.Errorf("initialize request failed: %w", err)
@@ -303,6 +303,19 @@ func (h *Handler) handleToolsCall(ctx context.Context, req *Request) (*Response,
 			Error:   NewError(ErrCodeInvalidParams, err.Error()),
 			ID:      req.ID,
 		}, nil
+	}
+
+	// Perform MCP initialize handshake if not yet done for this server instance.
+	if !h.pool.IsServerMCPInitialized(serverName) {
+		h.logger.Debug("initializing MCP session with server", "name", serverName)
+		if err := h.initializeServer(ctx, serverName); err != nil {
+			return &Response{
+				JSONRPC: JSONRPCVersion,
+				Error:   NewError(ErrCodeServerError, fmt.Sprintf("server initialization failed: %v", err)),
+				ID:      req.ID,
+			}, nil
+		}
+		h.pool.MarkServerMCPInitialized(serverName)
 	}
 
 	newParams := ToolsCallParams{
@@ -706,6 +719,31 @@ func (h *Handler) handleInvokeTool(ctx context.Context, req *Request, params Too
 		time.Sleep(500 * time.Millisecond)
 	}
 
+	// Perform MCP initialize handshake if not yet done for this server instance.
+	// The MCP protocol requires initialize + notifications/initialized before any tool call.
+	if !h.pool.IsServerMCPInitialized(serverName) {
+		h.logger.Debug("initializing MCP session with server", "name", serverName)
+		if err := h.initializeServer(ctx, serverName); err != nil {
+			h.logger.Error("invoke_tool: server initialization failed", "server", serverName, "error", err)
+			schema := h.lookupToolSchema(serverName, toolName)
+			enrichedError := FormatErrorWithHint(fmt.Sprintf("server initialization failed: %v", err), serverName, toolName)
+			errResp := NewError(ErrCodeServerError, enrichedError)
+			if schema != nil {
+				dataBytes, _ := json.Marshal(map[string]interface{}{
+					"tool":   toolName,
+					"schema": json.RawMessage(schema),
+				})
+				errResp.Data = dataBytes
+			}
+			return &Response{
+				JSONRPC: JSONRPCVersion,
+				Error:   errResp,
+				ID:      req.ID,
+			}, nil
+		}
+		h.pool.MarkServerMCPInitialized(serverName)
+	}
+
 	newParams := ToolsCallParams{
 		Name:      toolName,
 		Arguments: arguments,
@@ -717,25 +755,6 @@ func (h *Handler) handleInvokeTool(ctx context.Context, req *Request, params Too
 		h.logger.Error("invoke_tool failed", "server", serverName, "tool", toolName, "error", err)
 		schema := h.lookupToolSchema(serverName, toolName)
 		enrichedError := FormatErrorWithHint(fmt.Sprintf("tool invocation failed: %v", err), serverName, toolName)
-		errResp := NewError(ErrCodeServerError, enrichedError)
-		if schema != nil {
-			dataBytes, _ := json.Marshal(map[string]interface{}{
-				"tool":   toolName,
-				"schema": json.RawMessage(schema),
-			})
-			errResp.Data = dataBytes
-		}
-		return &Response{
-			JSONRPC: JSONRPCVersion,
-			Error:   errResp,
-			ID:      req.ID,
-		}, nil
-	}
-
-	if resp.Error != nil {
-		h.logger.Error("invoke_tool received error from server", "server", serverName, "tool", toolName, "error", resp.Error.Message)
-		schema := h.lookupToolSchema(serverName, toolName)
-		enrichedError := FormatErrorWithHint(fmt.Sprintf("tool invocation failed: %s", resp.Error.Message), serverName, toolName)
 		errResp := NewError(ErrCodeServerError, enrichedError)
 		if schema != nil {
 			dataBytes, _ := json.Marshal(map[string]interface{}{

--- a/pkg/mcp/handlers_test.go
+++ b/pkg/mcp/handlers_test.go
@@ -94,6 +94,13 @@ func (m *mockPool) Close() error {
 	return nil
 }
 
+func (m *mockPool) IsServerMCPInitialized(name string) bool {
+	return false
+}
+
+func (m *mockPool) MarkServerMCPInitialized(name string) {
+}
+
 func (m *mockPool) SetServerState(name string, state pool.ServerState) {
 	m.servers[name] = string(state)
 }

--- a/pkg/pool/http_pool.go
+++ b/pkg/pool/http_pool.go
@@ -370,6 +370,13 @@ func (p *HTTPClientPool) RestartServer(ctx context.Context, name string) error {
 	return nil
 }
 
+func (p *HTTPClientPool) IsServerMCPInitialized(name string) bool {
+	return true
+}
+
+func (p *HTTPClientPool) MarkServerMCPInitialized(name string) {
+}
+
 func (p *HTTPClientPool) Close() error {
 	p.cancel()
 
@@ -471,6 +478,31 @@ func (p *UnifiedPool) RestartServer(ctx context.Context, name string) error {
 		return p.ssePool.RestartServer(ctx, name)
 	}
 	return fmt.Errorf("server %s not found", name)
+}
+
+func (p *UnifiedPool) IsServerMCPInitialized(name string) bool {
+	if p.stdioPool.HasServer(name) {
+		return p.stdioPool.IsServerMCPInitialized(name)
+	}
+	if p.httpPool.HasServer(name) {
+		return p.httpPool.IsServerMCPInitialized(name)
+	}
+	if p.ssePool != nil {
+		return p.ssePool.IsServerMCPInitialized(name)
+	}
+	return false
+}
+
+func (p *UnifiedPool) MarkServerMCPInitialized(name string) {
+	if p.stdioPool.HasServer(name) {
+		p.stdioPool.MarkServerMCPInitialized(name)
+	}
+	if p.httpPool.HasServer(name) {
+		p.httpPool.MarkServerMCPInitialized(name)
+	}
+	if p.ssePool != nil {
+		p.ssePool.MarkServerMCPInitialized(name)
+	}
 }
 
 func (p *UnifiedPool) SendRequestToServerWithID(ctx context.Context, name string, method string, params json.RawMessage, timeout time.Duration, id int) (*Response, error) {

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -24,6 +24,8 @@ type ServerSource interface {
 	ListServers() []string
 	GetServerState(name string) (ServerState, error)
 	RestartServer(ctx context.Context, name string) error
+	IsServerMCPInitialized(name string) bool
+	MarkServerMCPInitialized(name string)
 	Close() error
 }
 
@@ -213,6 +215,22 @@ func (p *StdioPool) GetOrStartServer(ctx context.Context, name string) (*StdioSe
 
 	p.logger.Info("server restarted and ready", "name", name)
 	return server, nil
+}
+
+func (p *StdioPool) IsServerMCPInitialized(name string) bool {
+	server, err := p.GetServer(name)
+	if err != nil {
+		return false
+	}
+	return server.IsMCPInitialized()
+}
+
+func (p *StdioPool) MarkServerMCPInitialized(name string) {
+	server, err := p.GetServer(name)
+	if err != nil {
+		return
+	}
+	server.SetMCPInitialized()
 }
 
 func (p *StdioPool) waitForServerReady(ctx context.Context, name string, timeout time.Duration) error {

--- a/pkg/pool/server.go
+++ b/pkg/pool/server.go
@@ -84,6 +84,7 @@ type StdioServerV2 struct {
 	logger          *slog.Logger
 	stopChOnce      sync.Once
 	wg              sync.WaitGroup
+	mcpInitialized  atomic.Bool
 }
 
 func newServerV2(name string, config StdioServerConfig, logger *slog.Logger) *StdioServerV2 {
@@ -163,6 +164,14 @@ func toServerState(state int32) ServerState {
 	}
 }
 
+func (s *StdioServerV2) IsMCPInitialized() bool {
+	return s.mcpInitialized.Load()
+}
+
+func (s *StdioServerV2) SetMCPInitialized() {
+	s.mcpInitialized.Store(true)
+}
+
 func (s *StdioServerV2) spawn(ctx context.Context) error {
 	s.mu.Lock()
 
@@ -219,6 +228,7 @@ func (s *StdioServerV2) spawn(ctx context.Context) error {
 	atomic.StoreInt32(&s.state, stateIdle)
 	s.restartCount = 0
 	s.backoff = time.Second
+	s.mcpInitialized.Store(false)
 	s.stats.RestartCount++
 	s.stats.CurrentBackoff = s.backoff
 

--- a/pkg/pool/sse_pool.go
+++ b/pkg/pool/sse_pool.go
@@ -332,6 +332,13 @@ func (p *SSEPool) RestartServer(ctx context.Context, name string) error {
 	return nil
 }
 
+func (p *SSEPool) IsServerMCPInitialized(name string) bool {
+	return true
+}
+
+func (p *SSEPool) MarkServerMCPInitialized(name string) {
+}
+
 func (p *SSEPool) Close() error {
 	p.cancel()
 


### PR DESCRIPTION
## Summary

Fixes a critical bug where `tools/call` requests (including those routed through the `invoke_tool` gateway tool) were forwarded to backend stdio servers **before the MCP initialization handshake** was completed. Backend servers using strict MCP SDK implementations (e.g., Garmin MCP, Intervals.icu MCP) reject requests sent prior to initialization with: `"Received request before initialization was complete"`.

## Root Cause

In `pkg/mcp/handlers.go`, both `handleToolsCall` and `handleInvokeTool` sent `tools/call` JSON-RPC messages directly to the backend server without first performing the MCP `initialize` + `notifications/initialized` handshake.

While `initializeServer()` existed (used by `refreshToolCacheFromServers` for `tools/list`), it was never called before `tools/call` dispatches.

## Changes

| File | Change |
|------|--------|
| `pkg/pool/server.go` | Added `mcpInitialized atomic.Bool` to `StdioServerV2` with `SetMCPInitialized()` / `IsMCPInitialized()` methods. Reset on spawn. |
| `pkg/pool/pool.go` | Added `IsServerMCPInitialized(name)` and `MarkServerMCPInitialized(name)` to `StdioPool` and the `Pool` interface. |
| `pkg/pool/sse_pool.go` | Added `IsServerMCPInitialized` / `MarkServerMCPInitialized` (no-op stubs returning true — SSE handles its own lifecycle). |
| `pkg/pool/http_pool.go` | Added `IsServerMCPInitialized` / `MarkServerMCPInitialized` to `HTTPClientPool` (no-op stubs) and delegating implementations on `UnifiedPool`. |
| `pkg/mcp/handlers.go` | **Key fix**: In `handleToolsCall` and `handleInvokeTool`, check `IsServerMCPInitialized` before forwarding. If not initialized, call `initializeServer()` with 120s timeout, then `MarkServerMCPInitialized`. On init failure, return a proper error response immediately (instead of silently cascading to a failed tool call). |

## Verification

Manually tested end-to-end with Garmin MCP through leanproxy:

- `leanproxy_list_tools` garmin → **122 tools returned** (initialization succeeded)
- `leanproxy_invoke_tool` garmin garmin_get_activities_fordate date=2026-05-31 → **returned activity data** (13.47km run, "Willems Course à pied")

Before the fix, both calls failed with `"Received request before initialization was complete"`.

All existing unit tests pass.