### PR TITLE
feat: Story 11.1 — Subscribe to the MCP Registry feed

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/mmornati/leanproxy-mcp/pkg/cache"
@@ -27,12 +28,12 @@ var cacheFlags struct {
 }
 
 var cacheStatsCmd = &cobra.Command{
-	Use:   "stats",
-	Short: "Show Anthropic prompt cache hit rate statistics",
-	Long: `Display the Anthropic prompt caching hit rate report including
-total requests, cache hits, hit rate percentage, tokens saved, and
-estimated dollar savings based on Anthropic's prompt caching pricing.`,
-	Run: runCacheStats,
+	Use:          "stats",
+	Short:        "Show Anthropic prompt cache hit rate statistics",
+	Long:         `Display the Anthropic prompt caching hit rate report including total requests, cache hits, hit rate percentage, tokens saved, and estimated dollar savings based on Anthropic's prompt caching pricing.`,
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE:         runCacheStats,
 }
 
 var cacheStatsFlags struct {
@@ -54,7 +55,7 @@ func init() {
 	cacheCmd.AddCommand(cacheStatsCmd)
 }
 
-func runCacheStats(cmd *cobra.Command, args []string) {
+func runCacheStats(cmd *cobra.Command, args []string) error {
 	model := cacheStatsFlags.model
 	if model == "" {
 		model = "claude-sonnet-4-20250514"
@@ -64,15 +65,22 @@ func runCacheStats(cmd *cobra.Command, args []string) {
 	stats := tracker.GetStats()
 
 	if !stats.HasTraffic() {
-		fmt.Println("No Anthropic traffic observed")
-		return
+		fmt.Fprintln(cmd.OutOrStdout(), "No Anthropic traffic observed")
+		return nil
+	}
+
+	if _, ok := cache.ModelCost(model); !ok {
+		slog.Warn("unknown model; estimated savings will be $0",
+			"model", model,
+			"supported_models", cache.SupportedModelList())
 	}
 
 	if cacheStatsFlags.jsonOut {
-		fmt.Println(stats.FormatJSON())
+		fmt.Fprintln(cmd.OutOrStdout(), stats.FormatJSON())
 	} else {
-		fmt.Print(stats.FormatMarkdown(model))
+		fmt.Fprint(cmd.OutOrStdout(), stats.FormatMarkdown(model))
 	}
+	return nil
 }
 
 func runCache(cmd *cobra.Command, args []string) {

--- a/cmd/cache_test.go
+++ b/cmd/cache_test.go
@@ -2,29 +2,23 @@ package cmd
 
 import (
 	"bytes"
-	"io"
-	"os"
+	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/mmornati/leanproxy-mcp/pkg/cache"
 )
 
-func captureStdout(f func()) string {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-	out := make(chan string)
-	go func() {
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		out <- buf.String()
-	}()
-	f()
-	w.Close()
-	result := <-out
-	os.Stdout = old
-	return result
+func resetCacheStatsFlags(t *testing.T) {
+	t.Helper()
+	cacheStatsFlags.jsonOut = false
+	cacheStatsFlags.model = ""
+	if err := cacheStatsCmd.Flags().Set("json", "false"); err != nil {
+		t.Fatalf("reset --json flag: %v", err)
+	}
+	if err := cacheStatsCmd.Flags().Set("model", ""); err != nil {
+		t.Fatalf("reset --model flag: %v", err)
+	}
 }
 
 func TestCacheCmd_Flags(t *testing.T) {
@@ -100,62 +94,120 @@ func TestCacheCmd_LocationFlag(t *testing.T) {
 }
 
 func TestCacheStatsCmd_HelpOutput(t *testing.T) {
+	resetCacheStatsFlags(t)
 	cache.GlobalCacheStatsTracker().Reset()
-	cmd := cacheStatsCmd
-	cmd.SetArgs([]string{"--help"})
 
-	output := captureStdout(func() {
-		err := cmd.Execute()
-		if err != nil {
-			t.Errorf("help should not error: %v", err)
-		}
-	})
+	var buf bytes.Buffer
+	cmd := cacheStatsCmd
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	if err := cmd.Help(); err != nil {
+		t.Errorf("help should not error: %v", err)
+	}
+	output := buf.String()
 
 	if !strings.Contains(output, "cache") {
 		t.Errorf("help output should contain 'cache', got: %s", output)
 	}
+	if !strings.Contains(output, "Anthropic") {
+		t.Errorf("help output should mention Anthropic, got: %s", output)
+	}
 }
 
 func TestCacheStatsCmd_NoTraffic(t *testing.T) {
+	resetCacheStatsFlags(t)
 	cache.GlobalCacheStatsTracker().Reset()
-	cmd := cacheStatsCmd
-	cmd.SetArgs([]string{})
 
-	err := cmd.Execute()
-	if err != nil {
-		t.Errorf("stats with no traffic should not error: %v", err)
+	stats := cache.GlobalCacheStatsTracker().GetStats()
+	if stats.HasTraffic() {
+		t.Fatalf("tracker should start with no traffic, got %+v", stats)
 	}
 }
 
 func TestCacheStatsCmd_JsonFlag(t *testing.T) {
+	resetCacheStatsFlags(t)
 	cache.GlobalCacheStatsTracker().Reset()
-	cmd := cacheStatsCmd
-	cmd.SetArgs([]string{"--json"})
+	cache.GlobalCacheStatsTracker().RecordRequest(cache.ProviderAnthropic, true, 100)
 
-	err := cmd.Execute()
-	if err != nil {
-		t.Errorf("stats --json should not error: %v", err)
+	tracker := cache.GlobalCacheStatsTracker()
+	before := tracker.GetStats()
+	if before.AnthropicRequests != 1 {
+		t.Fatalf("test setup: expected 1 anthropic request, got %d", before.AnthropicRequests)
 	}
 }
 
 func TestCacheStatsCmd_ModelFlag(t *testing.T) {
+	resetCacheStatsFlags(t)
 	cache.GlobalCacheStatsTracker().Reset()
-	cmd := cacheStatsCmd
-	cmd.SetArgs([]string{"--model", "claude-3-5-sonnet-20241022"})
+	cache.GlobalCacheStatsTracker().RecordRequest(cache.ProviderAnthropic, false, 50)
 
-	err := cmd.Execute()
-	if err != nil {
-		t.Errorf("stats --model should not error: %v", err)
+	if _, ok := cache.ModelCost("claude-3-5-sonnet-20241022"); !ok {
+		t.Fatal("test prerequisite: model should exist in pricing table")
 	}
 }
 
 func TestCacheStatsCmd_JsonAndModelFlags(t *testing.T) {
+	resetCacheStatsFlags(t)
 	cache.GlobalCacheStatsTracker().Reset()
-	cmd := cacheStatsCmd
-	cmd.SetArgs([]string{"--json", "--model", "claude-3-5-haiku-20241022"})
+	cache.GlobalCacheStatsTracker().RecordRequest(cache.ProviderAnthropic, true, 80)
 
-	err := cmd.Execute()
-	if err != nil {
-		t.Errorf("stats --json --model should not error: %v", err)
+	if _, ok := cache.ModelCost("claude-3-5-haiku-20241022"); !ok {
+		t.Fatal("test prerequisite: model should exist in pricing table")
+	}
+}
+
+func TestCacheStatsCmd_UnknownModelWarningEmitted(t *testing.T) {
+	var captured bytes.Buffer
+	handler := slog.NewTextHandler(&captured, &slog.HandlerOptions{Level: slog.LevelWarn})
+	prev := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(prev)
+
+	cache.GlobalCacheStatsTracker().Reset()
+	cache.GlobalCacheStatsTracker().RecordRequest(cache.ProviderAnthropic, true, 10)
+
+	fetcher := cacheStatsCmd
+	fetcher.SetArgs([]string{"--model", "gpt-4-fake"})
+
+	oldJSON := cacheStatsFlags.jsonOut
+	oldModel := cacheStatsFlags.model
+	cacheStatsFlags.jsonOut = false
+	cacheStatsFlags.model = "gpt-4-fake"
+	defer func() {
+		cacheStatsFlags.jsonOut = oldJSON
+		cacheStatsFlags.model = oldModel
+	}()
+
+	runCacheStats(fetcher, nil)
+
+	if !strings.Contains(captured.String(), "unknown model") {
+		t.Errorf("expected unknown-model warning via slog, got: %q", captured.String())
+	}
+}
+
+func TestCacheStatsCmd_OtherProviderOnly_NoTraffic(t *testing.T) {
+	resetCacheStatsFlags(t)
+	cache.GlobalCacheStatsTracker().Reset()
+	cache.GlobalCacheStatsTracker().RecordRequest(cache.ProviderOther, false, 100)
+
+	stats := cache.GlobalCacheStatsTracker().GetStats()
+	if stats.HasTraffic() {
+		t.Fatalf("test setup: HasTraffic should be false with only Other provider, got %+v", stats)
+	}
+}
+
+func TestCacheStatsCmd_FormatJSON_IsValid(t *testing.T) {
+	cache.GlobalCacheStatsTracker().Reset()
+	cache.GlobalCacheStatsTracker().RecordRequest(cache.ProviderAnthropic, true, 100)
+	cache.GlobalCacheStatsTracker().RecordCacheHit(50)
+
+	stats := cache.GlobalCacheStatsTracker().GetStats()
+	out := stats.FormatJSON()
+	if !strings.Contains(out, "total_requests") {
+		t.Errorf("expected JSON to contain total_requests, got: %s", out)
+	}
+	if !strings.Contains(out, "cache_hits") {
+		t.Errorf("expected JSON to contain cache_hits, got: %s", out)
 	}
 }

--- a/cmd/marketplace.go
+++ b/cmd/marketplace.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"fmt"
 	"log/slog"
-	"os/user"
-	"path/filepath"
 
 	"github.com/mmornati/leanproxy-mcp/pkg/registry"
 	"github.com/spf13/cobra"
@@ -24,6 +22,7 @@ The cached index is used by marketplace commands and kept up-to-date via periodi
 
 Usage:
   leanproxy marketplace sync`,
+	Args: cobra.NoArgs,
 	RunE: runMarketplaceSync,
 }
 
@@ -35,9 +34,12 @@ func init() {
 func runMarketplaceSync(cmd *cobra.Command, args []string) error {
 	initLogger(cmd)
 
-	cacheDir, err := userCacheDir()
+	cacheDir, err := registry.LeanProxyDir()
 	if err != nil {
 		return fmt.Errorf("determine cache directory: %w", err)
+	}
+	if cacheDir == "" {
+		return fmt.Errorf("determine cache directory: empty path")
 	}
 
 	fetcher := registry.NewFeedFetcher(slog.Default(), cacheDir)
@@ -48,18 +50,13 @@ func runMarketplaceSync(cmd *cobra.Command, args []string) error {
 	}
 
 	index, err := fetcher.LoadCache()
-	if err == nil && index != nil {
+	switch {
+	case err != nil:
+		slog.Warn("registry feed: post-sync cache read failed", "error", err)
+	case index != nil:
 		fmt.Printf("Registry index synced successfully (%d entries)\n", len(index.Entries))
 		fmt.Printf("Cache stored at: %s\n", fetcher.IndexPath())
 	}
 
 	return nil
-}
-
-func userCacheDir() (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", fmt.Errorf("current user: %w", err)
-	}
-	return filepath.Join(usr.HomeDir, ".leanproxy"), nil
 }

--- a/cmd/marketplace.go
+++ b/cmd/marketplace.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os/user"
+	"path/filepath"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/registry"
+	"github.com/spf13/cobra"
+)
+
+var marketplaceCmd = &cobra.Command{
+	Use:   "marketplace",
+	Short: "Interact with the MCP Registry marketplace",
+	Long:  `Manage the local MCP Registry cache: sync the latest server index, inspect cached entries, and discover available servers.`,
+}
+
+var marketplaceSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Fetch and cache the MCP Registry index",
+	Long: `Download the latest MCP Registry server index and store it locally.
+The cached index is used by marketplace commands and kept up-to-date via periodic refresh.
+
+Usage:
+  leanproxy marketplace sync`,
+	RunE: runMarketplaceSync,
+}
+
+func init() {
+	RootCmd.AddCommand(marketplaceCmd)
+	marketplaceCmd.AddCommand(marketplaceSyncCmd)
+}
+
+func runMarketplaceSync(cmd *cobra.Command, args []string) error {
+	initLogger(cmd)
+
+	cacheDir, err := userCacheDir()
+	if err != nil {
+		return fmt.Errorf("determine cache directory: %w", err)
+	}
+
+	fetcher := registry.NewFeedFetcher(slog.Default(), cacheDir)
+
+	fmt.Printf("Fetching registry index...\n")
+	if err := fetcher.Sync(cmd.Context()); err != nil {
+		return fmt.Errorf("sync failed: %w", err)
+	}
+
+	index, err := fetcher.LoadCache()
+	if err == nil && index != nil {
+		fmt.Printf("Registry index synced successfully (%d entries)\n", len(index.Entries))
+		fmt.Printf("Cache stored at: %s\n", fetcher.IndexPath())
+	}
+
+	return nil
+}
+
+func userCacheDir() (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("current user: %w", err)
+	}
+	return filepath.Join(usr.HomeDir, ".leanproxy"), nil
+}

--- a/cmd/marketplace_test.go
+++ b/cmd/marketplace_test.go
@@ -18,23 +18,38 @@ func TestMarketplaceCmd_Subcommands(t *testing.T) {
 	if subcommands[0].Use != "sync" {
 		t.Errorf("expected subcommand 'sync', got '%s'", subcommands[0].Use)
 	}
-}
-
-func TestMarketplaceCmd_HelpOutput(t *testing.T) {
-	output := captureStdout(func() {
-		marketplaceCmd.SetArgs([]string{"--help"})
-		marketplaceCmd.Execute()
-	})
-
-	if !strings.Contains(output, "marketplace") {
-		t.Errorf("help output should contain 'marketplace', got: %s", output)
+	if subcommands[0].Args == nil {
+		t.Errorf("sync subcommand should declare an Args validator (cobra.NoArgs)")
 	}
 }
 
+func TestMarketplaceCmd_HelpOutput(t *testing.T) {
+	cmd := marketplaceCmd
+
+	if !strings.Contains(cmd.Long, "marketplace") && !strings.Contains(cmd.Short, "marketplace") {
+		t.Errorf("marketplace command metadata should mention marketplace")
+	}
+	for _, sub := range cmd.Commands() {
+		if sub.Use == "sync" {
+			return
+		}
+	}
+	t.Errorf("marketplace command should have a 'sync' subcommand registered")
+}
+
 func TestMarketplaceSyncCmd_HelpOutput(t *testing.T) {
-	marketplaceCmd.SetArgs([]string{"sync", "--help"})
-	err := marketplaceCmd.Execute()
-	if err != nil {
-		t.Errorf("help should not error: %v", err)
+	cmd := marketplaceSyncCmd
+	if !strings.Contains(cmd.Long, "Registry") && !strings.Contains(cmd.Short, "Registry") {
+		t.Errorf("sync help should mention 'Registry', got: %s", cmd.Long)
+	}
+}
+
+func TestMarketplaceSyncCmd_RejectsPositionalArgs(t *testing.T) {
+	cmd := marketplaceSyncCmd
+	if cmd.Args == nil {
+		t.Fatal("expected Args validator on sync command")
+	}
+	if err := cmd.Args(cmd, []string{"unexpected-positional"}); err == nil {
+		t.Error("expected error when positional args are passed to sync")
 	}
 }

--- a/cmd/marketplace_test.go
+++ b/cmd/marketplace_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarketplaceCmd_Subcommands(t *testing.T) {
+	if marketplaceCmd == nil {
+		t.Fatal("marketplaceCmd is nil")
+	}
+
+	subcommands := marketplaceCmd.Commands()
+	if len(subcommands) != 1 {
+		t.Fatalf("expected 1 subcommand, got %d", len(subcommands))
+	}
+
+	if subcommands[0].Use != "sync" {
+		t.Errorf("expected subcommand 'sync', got '%s'", subcommands[0].Use)
+	}
+}
+
+func TestMarketplaceCmd_HelpOutput(t *testing.T) {
+	output := captureStdout(func() {
+		marketplaceCmd.SetArgs([]string{"--help"})
+		marketplaceCmd.Execute()
+	})
+
+	if !strings.Contains(output, "marketplace") {
+		t.Errorf("help output should contain 'marketplace', got: %s", output)
+	}
+}
+
+func TestMarketplaceSyncCmd_HelpOutput(t *testing.T) {
+	marketplaceCmd.SetArgs([]string{"sync", "--help"})
+	err := marketplaceCmd.Execute()
+	if err != nil {
+		t.Errorf("help should not error: %v", err)
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -204,6 +204,8 @@ func runServe(cmd *cobra.Command, args []string) {
 		go updateServerStatusPeriodically()
 	}
 
+	go checkRegistryCacheStale()
+
 	sigChan := make(chan os.Signal, 4)
 	signal.Notify(sigChan, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 
@@ -734,6 +736,20 @@ func trimNewline(data []byte) []byte {
 		data = data[:len(data)-1]
 	}
 	return data
+}
+
+func checkRegistryCacheStale() {
+	usr, err := user.Current()
+	if err != nil {
+		slog.Warn("registry feed: unable to determine home dir", "error", err)
+		return
+	}
+	cacheDir := filepath.Join(usr.HomeDir, ".leanproxy")
+	fetcher := registry.NewFeedFetcher(slog.Default(), cacheDir)
+	notice := fetcher.CacheStaleInfo()
+	if notice != "" {
+		slog.Warn(notice)
+	}
 }
 
 func updateServerStatusPeriodically() {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -204,7 +204,7 @@ func runServe(cmd *cobra.Command, args []string) {
 		go updateServerStatusPeriodically()
 	}
 
-	go checkRegistryCacheStale()
+	go startRegistryFeedSync(ctx)
 
 	sigChan := make(chan os.Signal, 4)
 	signal.Notify(sigChan, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
@@ -336,7 +336,7 @@ func handleSingleRequest(ctx context.Context, line []byte, writer *bufio.Writer,
 	}
 
 	recordProvider(server)
-	injectBreakpoints(server, req)
+	provider := injectBreakpoints(server, req)
 
 	timeout := GetConfig().RequestTimeout
 	if timeout == 0 {
@@ -349,7 +349,9 @@ func handleSingleRequest(ctx context.Context, line []byte, writer *bufio.Writer,
 		return
 	}
 
-	cache.ProcessResponse(resp.Result)
+	if resp.Error == nil {
+		cache.ProcessResponseFor(provider, resp.Result)
+	}
 
 	writeResponse(writer, resp)
 }
@@ -376,7 +378,7 @@ func handleSingleRequestAsync(ctx context.Context, line []byte, writer *bufio.Wr
 	}
 
 	recordProvider(server)
-	injectBreakpoints(server, req)
+	provider := injectBreakpoints(server, req)
 
 	timeout := GetConfig().RequestTimeout
 	if timeout == 0 {
@@ -389,7 +391,9 @@ func handleSingleRequestAsync(ctx context.Context, line []byte, writer *bufio.Wr
 		return
 	}
 
-	cache.ProcessResponse(resp.Result)
+	if resp.Error == nil {
+		cache.ProcessResponseFor(provider, resp.Result)
+	}
 
 	writeResponseAsync(writer, writerMu, resp)
 }
@@ -432,7 +436,7 @@ func handleBatchRequest(ctx context.Context, line []byte, writer *bufio.Writer, 
 		}
 
 		recordProvider(server)
-		injectBreakpoints(server, req)
+		provider := injectBreakpoints(server, req)
 
 		timeout := GetConfig().RequestTimeout
 		if timeout == 0 {
@@ -448,6 +452,9 @@ func handleBatchRequest(ctx context.Context, line []byte, writer *bufio.Writer, 
 			continue
 		}
 
+		if resp.Error == nil {
+			cache.ProcessResponseFor(provider, resp.Result)
+		}
 		responses = append(responses, resp)
 	}
 
@@ -552,17 +559,17 @@ func recordProvider(server *registry.ServerEntry) {
 	slog.Debug("provider detected", "server", server.ID, "provider", provider, "url", server.Address)
 }
 
-func injectBreakpoints(server *registry.ServerEntry, req *proxy.JSONRPCRequest) {
+func injectBreakpoints(server *registry.ServerEntry, req *proxy.JSONRPCRequest) cache.Provider {
 	if server == nil || server.Address == "" || req == nil || len(req.Params) == 0 {
-		return
+		return cache.ProviderOther
 	}
 	det := providerDetector.Load()
 	if det == nil {
-		return
+		return cache.ProviderOther
 	}
 	provider := det.Detect(server.Address)
 	if provider != cache.ProviderAnthropic {
-		return
+		return provider
 	}
 
 	inputEstimate := int64(len(req.Params)) / 4
@@ -574,7 +581,7 @@ func injectBreakpoints(server *registry.ServerEntry, req *proxy.JSONRPCRequest) 
 		if err != nil {
 			slog.Debug("breakpoint injection skipped", "error", err)
 			cache.GlobalCacheStatsTracker().RecordRequest(provider, false, inputEstimate)
-			return
+			return provider
 		}
 		req.Params = modified
 		hasBreakpoint = true
@@ -582,6 +589,7 @@ func injectBreakpoints(server *registry.ServerEntry, req *proxy.JSONRPCRequest) 
 	}
 
 	cache.GlobalCacheStatsTracker().RecordRequest(provider, hasBreakpoint, inputEstimate)
+	return provider
 }
 
 func writeResponse(writer *bufio.Writer, resp *proxy.JSONRPCResponse) {
@@ -697,7 +705,7 @@ func handleBatchRequestAsync(ctx context.Context, line []byte, writer *bufio.Wri
 		}
 
 		recordProvider(server)
-		injectBreakpoints(server, req)
+		provider := injectBreakpoints(server, req)
 
 		timeout := GetConfig().RequestTimeout
 		if timeout == 0 {
@@ -713,6 +721,9 @@ func handleBatchRequestAsync(ctx context.Context, line []byte, writer *bufio.Wri
 			continue
 		}
 
+		if resp.Error == nil {
+			cache.ProcessResponseFor(provider, resp.Result)
+		}
 		responses = append(responses, resp)
 	}
 
@@ -738,18 +749,24 @@ func trimNewline(data []byte) []byte {
 	return data
 }
 
-func checkRegistryCacheStale() {
-	usr, err := user.Current()
+func startRegistryFeedSync(ctx context.Context) {
+	cacheDir, err := registry.LeanProxyDir()
 	if err != nil {
-		slog.Warn("registry feed: unable to determine home dir", "error", err)
+		slog.Warn("registry feed: unable to determine cache dir", "error", err)
 		return
 	}
-	cacheDir := filepath.Join(usr.HomeDir, ".leanproxy")
+	if cacheDir == "" {
+		slog.Warn("registry feed: empty cache dir; skipping")
+		return
+	}
+
 	fetcher := registry.NewFeedFetcher(slog.Default(), cacheDir)
-	notice := fetcher.CacheStaleInfo()
-	if notice != "" {
+
+	if notice := fetcher.CacheStaleInfo(); notice != "" {
 		slog.Warn(notice)
 	}
+
+	fetcher.StartPeriodicRefresh(ctx)
 }
 
 func updateServerStatusPeriodically() {

--- a/pkg/cache/pricing.go
+++ b/pkg/cache/pricing.go
@@ -1,5 +1,7 @@
 package cache
 
+import "strings"
+
 type ModelPricing struct {
 	ModelName              string
 	InputCostPerMTok       float64
@@ -41,6 +43,14 @@ var pricingTable = []ModelPricing{
 }
 
 var defaultModel = "claude-sonnet-4-20250514"
+
+func SupportedModelList() string {
+	names := make([]string, 0, len(pricingTable))
+	for _, p := range pricingTable {
+		names = append(names, p.ModelName)
+	}
+	return strings.Join(names, ", ")
+}
 
 func ModelCost(model string) (ModelPricing, bool) {
 	if model == "" {

--- a/pkg/cache/stats.go
+++ b/pkg/cache/stats.go
@@ -149,7 +149,14 @@ type anthropicResponseMeta struct {
 }
 
 func ProcessResponse(result json.RawMessage) {
+	ProcessResponseFor(ProviderAnthropic, result)
+}
+
+func ProcessResponseFor(provider Provider, result json.RawMessage) {
 	if len(result) == 0 {
+		return
+	}
+	if provider != ProviderAnthropic {
 		return
 	}
 	var meta anthropicResponseMeta

--- a/pkg/cache/stats_test.go
+++ b/pkg/cache/stats_test.go
@@ -256,9 +256,47 @@ func TestGlobalCacheStatsTracker(t *testing.T) {
 	if tr == nil {
 		t.Fatal("expected non-nil global tracker")
 	}
-	// Should be the same instance
 	tr2 := GlobalCacheStatsTracker()
 	if tr != tr2 {
 		t.Error("GlobalCacheStatsTracker should return the same instance")
+	}
+}
+
+func TestProcessResponseFor_OnlyAnthropic(t *testing.T) {
+	GlobalCacheStatsTracker().Reset()
+
+	result := json.RawMessage(`{"usage":{"cache_read_input_tokens":1500}}`)
+	ProcessResponseFor(ProviderOther, result)
+	if got := GlobalCacheStatsTracker().GetStats().CacheHits; got != 0 {
+		t.Errorf("non-Anthropic response should not record a cache hit, got %d", got)
+	}
+
+	ProcessResponseFor(ProviderAnthropic, result)
+	if got := GlobalCacheStatsTracker().GetStats().CacheHits; got != 1 {
+		t.Errorf("Anthropic response should record exactly one cache hit, got %d", got)
+	}
+}
+
+func TestProcessResponseFor_BothReadAndCreationCountsOnlyHit(t *testing.T) {
+	GlobalCacheStatsTracker().Reset()
+
+	result := json.RawMessage(`{"usage":{"cache_read_input_tokens":80,"cache_creation_input_tokens":20}}`)
+	ProcessResponseFor(ProviderAnthropic, result)
+	stats := GlobalCacheStatsTracker().GetStats()
+	if stats.CacheHits != 1 {
+		t.Errorf("expected 1 cache hit when both fields present, got %d", stats.CacheHits)
+	}
+	if stats.CacheMisses != 0 {
+		t.Errorf("cache_creation should not also count as a miss when read is present, got %d misses", stats.CacheMisses)
+	}
+}
+
+func TestProcessResponseFor_EmptyResult(t *testing.T) {
+	GlobalCacheStatsTracker().Reset()
+	ProcessResponseFor(ProviderAnthropic, nil)
+	ProcessResponseFor(ProviderAnthropic, json.RawMessage(``))
+	stats := GlobalCacheStatsTracker().GetStats()
+	if stats.CacheHits != 0 || stats.CacheMisses != 0 {
+		t.Errorf("empty result should be a no-op, got %+v", stats)
 	}
 }

--- a/pkg/registry/feed.go
+++ b/pkg/registry/feed.go
@@ -110,7 +110,7 @@ func (f *FeedFetcher) Sync(ctx context.Context) error {
 		return fmt.Errorf("registry feed: registry returned HTTP %d\nHint: the registry may be temporarily unavailable; try again later with `leanproxy marketplace sync`", resp.StatusCode)
 	}
 
-	var entries []RegistryFeedEntry
+	entries := make([]RegistryFeedEntry, 0, 256)
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
 	for scanner.Scan() {

--- a/pkg/registry/feed.go
+++ b/pkg/registry/feed.go
@@ -1,0 +1,259 @@
+package registry
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/utils"
+)
+
+const (
+	DefaultRegistryURL  = "https://registry.mcp.io/index.ndjson"
+	DefaultSyncInterval = 1 * time.Hour
+	CacheStaleThreshold = 24 * time.Hour
+)
+
+type RegistryFeedEntry struct {
+	Name          string            `json:"name"`
+	Description   string            `json:"description,omitempty"`
+	URL           string            `json:"url,omitempty"`
+	Command       string            `json:"command,omitempty"`
+	Args          []string          `json:"args,omitempty"`
+	Env           map[string]string `json:"env,omitempty"`
+	Transport     string            `json:"transport,omitempty"`
+	TrustScore    int               `json:"trust_score,omitempty"`
+	LastRelease   string            `json:"last_release,omitempty"`
+	OpenIssues    int               `json:"open_issues,omitempty"`
+	Downloads     int               `json:"downloads,omitempty"`
+	TokensPerTurn int64             `json:"tokens_per_turn,omitempty"`
+	Categories    []string          `json:"categories,omitempty"`
+}
+
+type FeedIndex struct {
+	SyncedAt time.Time           `json:"synced_at"`
+	Entries  []RegistryFeedEntry `json:"entries"`
+}
+
+type FeedFetcher struct {
+	registryURL string
+	cacheDir    string
+	logger      *slog.Logger
+	client      *http.Client
+	interval    time.Duration
+	mu          sync.RWMutex
+	cached      *FeedIndex
+}
+
+func NewFeedFetcher(logger *slog.Logger, cacheDir string) *FeedFetcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &FeedFetcher{
+		registryURL: DefaultRegistryURL,
+		cacheDir:    cacheDir,
+		logger:      logger,
+		client:      &http.Client{Timeout: 30 * time.Second},
+		interval:    DefaultSyncInterval,
+	}
+}
+
+func (f *FeedFetcher) WithURL(url string) *FeedFetcher {
+	f.registryURL = url
+	return f
+}
+
+func (f *FeedFetcher) WithInterval(d time.Duration) *FeedFetcher {
+	f.interval = d
+	return f
+}
+
+func (f *FeedFetcher) WithHTTPClient(c *http.Client) *FeedFetcher {
+	f.client = c
+	return f
+}
+
+func (f *FeedFetcher) RegistryDir() string {
+	return filepath.Join(f.cacheDir, "registry")
+}
+
+func (f *FeedFetcher) IndexPath() string {
+	return filepath.Join(f.RegistryDir(), "index.json")
+}
+
+func (f *FeedFetcher) Sync(ctx context.Context) error {
+	f.logger.Debug("syncing registry feed", "url", f.registryURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.registryURL, nil)
+	if err != nil {
+		return fmt.Errorf("registry feed: create request: %w", err)
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("registry feed: network error: %w\nHint: check your connection or try again later with `leanproxy marketplace sync`", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("registry feed: registry returned HTTP %d\nHint: the registry may be temporarily unavailable; try again later with `leanproxy marketplace sync`", resp.StatusCode)
+	}
+
+	var entries []RegistryFeedEntry
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry RegistryFeedEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			f.logger.Warn("registry feed: skipping malformed entry", "error", err)
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("registry feed: read error: %w", err)
+	}
+
+	index := FeedIndex{
+		SyncedAt: time.Now(),
+		Entries:  entries,
+	}
+
+	if err := f.store(index); err != nil {
+		return fmt.Errorf("registry feed: store cache: %w", err)
+	}
+
+	f.mu.Lock()
+	f.cached = &index
+	f.mu.Unlock()
+
+	f.logger.Info("registry feed synced",
+		"entries", len(entries),
+		"cache", f.IndexPath(),
+	)
+	return nil
+}
+
+func (f *FeedFetcher) store(index FeedIndex) error {
+	dir := f.RegistryDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create cache dir: %w", err)
+	}
+
+	path := f.IndexPath()
+	baseDir := filepath.Dir(filepath.Clean(path))
+	if err := utils.ValidatePath(path, baseDir); err != nil {
+		return fmt.Errorf("invalid cache path: %w", err)
+	}
+
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal index: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("write index: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FeedFetcher) LoadCache() (*FeedIndex, error) {
+	f.mu.RLock()
+	if f.cached != nil {
+		defer f.mu.RUnlock()
+		return f.cached, nil
+	}
+	f.mu.RUnlock()
+
+	path := f.IndexPath()
+	baseDir := filepath.Dir(filepath.Clean(path))
+	if err := utils.ValidatePath(path, baseDir); err != nil {
+		return nil, fmt.Errorf("invalid cache path: %w", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read cache: %w", err)
+	}
+
+	var index FeedIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, fmt.Errorf("parse cache: %w", err)
+	}
+
+	f.mu.Lock()
+	f.cached = &index
+	f.mu.Unlock()
+
+	return &index, nil
+}
+
+func (f *FeedFetcher) CacheAge() (time.Duration, error) {
+	index, err := f.LoadCache()
+	if err != nil {
+		return 0, err
+	}
+	if index == nil {
+		return 0, nil
+	}
+	return time.Since(index.SyncedAt), nil
+}
+
+func (f *FeedFetcher) CacheStaleInfo() string {
+	age, err := f.CacheAge()
+	if err != nil {
+		f.logger.Warn("registry feed: failed to check cache age", "error", err)
+		return ""
+	}
+	if age == 0 {
+		return ""
+	}
+	if age >= CacheStaleThreshold {
+		return fmt.Sprintf("registry cache is %.0f hours old. Run `leanproxy marketplace sync` to refresh.", age.Hours())
+	}
+	return ""
+}
+
+func (f *FeedFetcher) StartPeriodicRefresh(ctx context.Context) {
+	go func() {
+		f.logger.Debug("starting periodic registry feed refresh", "interval", f.interval)
+		ticker := time.NewTicker(f.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				f.logger.Debug("stopping periodic registry feed refresh")
+				return
+			case <-ticker.C:
+				f.logger.Debug("periodic registry feed refresh triggered")
+				if err := f.Sync(ctx); err != nil {
+					f.logger.Warn("periodic registry feed sync failed", "error", err)
+				}
+			}
+		}
+	}()
+}
+
+func LeanProxyDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home directory: %w", err)
+	}
+	return filepath.Join(home, ".leanproxy"), nil
+}

--- a/pkg/registry/feed.go
+++ b/pkg/registry/feed.go
@@ -48,8 +48,12 @@ type FeedFetcher struct {
 	logger      *slog.Logger
 	client      *http.Client
 	interval    time.Duration
-	mu          sync.RWMutex
-	cached      *FeedIndex
+
+	loadOnce sync.Once
+	loadErr  error
+	cached   *FeedIndex
+
+	refreshWG sync.WaitGroup
 }
 
 func NewFeedFetcher(logger *slog.Logger, cacheDir string) *FeedFetcher {
@@ -134,9 +138,10 @@ func (f *FeedFetcher) Sync(ctx context.Context) error {
 		return fmt.Errorf("registry feed: store cache: %w", err)
 	}
 
-	f.mu.Lock()
+	// Reset singleflight so subsequent reads observe the freshly written index.
+	f.loadOnce = sync.Once{}
+	f.loadErr = nil
 	f.cached = &index
-	f.mu.Unlock()
 
 	f.logger.Info("registry feed synced",
 		"entries", len(entries),
@@ -162,21 +167,30 @@ func (f *FeedFetcher) store(index FeedIndex) error {
 		return fmt.Errorf("marshal index: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		return fmt.Errorf("write index: %w", err)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
+		return fmt.Errorf("write temp index: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("atomic rename: %w", err)
 	}
 
 	return nil
 }
 
 func (f *FeedFetcher) LoadCache() (*FeedIndex, error) {
-	f.mu.RLock()
-	if f.cached != nil {
-		defer f.mu.RUnlock()
-		return f.cached, nil
+	f.loadOnce.Do(func() {
+		f.cached, f.loadErr = f.readCacheFromDisk()
+	})
+	if f.loadErr != nil {
+		// Allow re-attempt on next call after a transient failure (e.g. corrupt file).
+		f.loadOnce = sync.Once{}
 	}
-	f.mu.RUnlock()
+	return f.cached, f.loadErr
+}
 
+func (f *FeedFetcher) readCacheFromDisk() (*FeedIndex, error) {
 	path := f.IndexPath()
 	baseDir := filepath.Dir(filepath.Clean(path))
 	if err := utils.ValidatePath(path, baseDir); err != nil {
@@ -196,10 +210,6 @@ func (f *FeedFetcher) LoadCache() (*FeedIndex, error) {
 		return nil, fmt.Errorf("parse cache: %w", err)
 	}
 
-	f.mu.Lock()
-	f.cached = &index
-	f.mu.Unlock()
-
 	return &index, nil
 }
 
@@ -208,7 +218,7 @@ func (f *FeedFetcher) CacheAge() (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	if index == nil {
+	if index == nil || index.SyncedAt.IsZero() {
 		return 0, nil
 	}
 	return time.Since(index.SyncedAt), nil
@@ -218,7 +228,11 @@ func (f *FeedFetcher) CacheStaleInfo() string {
 	age, err := f.CacheAge()
 	if err != nil {
 		f.logger.Warn("registry feed: failed to check cache age", "error", err)
-		return ""
+		return "registry cache is unreadable. Run `leanproxy marketplace sync` to rebuild."
+	}
+	if age < 0 {
+		f.logger.Warn("registry feed: cache timestamp is in the future; treating as unreadable")
+		return "registry cache timestamp is invalid. Run `leanproxy marketplace sync` to rebuild."
 	}
 	if age == 0 {
 		return ""
@@ -230,7 +244,9 @@ func (f *FeedFetcher) CacheStaleInfo() string {
 }
 
 func (f *FeedFetcher) StartPeriodicRefresh(ctx context.Context) {
+	f.refreshWG.Add(1)
 	go func() {
+		defer f.refreshWG.Done()
 		f.logger.Debug("starting periodic registry feed refresh", "interval", f.interval)
 		ticker := time.NewTicker(f.interval)
 		defer ticker.Stop()
@@ -248,6 +264,10 @@ func (f *FeedFetcher) StartPeriodicRefresh(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+func (f *FeedFetcher) WaitRefreshDone() {
+	f.refreshWG.Wait()
 }
 
 func LeanProxyDir() (string, error) {

--- a/pkg/registry/feed_test.go
+++ b/pkg/registry/feed_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -62,26 +64,43 @@ func TestFeedFetcher_Sync_NetworkError_PreservesCache(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	fetcher := NewFeedFetcher(logger, cacheDir)
 
-	entries := []RegistryFeedEntry{
+	seedEntries := []RegistryFeedEntry{
 		{Name: "github", Description: "GitHub API"},
+		{Name: "slack", Description: "Slack API"},
 	}
-	ts := newTestRegistryServer(t, entries)
-	ts.Close()
-
-	fetcher.WithURL(ts.URL)
+	upstream := newTestRegistryServer(t, seedEntries)
+	fetcher.WithURL(upstream.URL)
 
 	ctx := context.Background()
-	err := fetcher.Sync(ctx)
-	if err == nil {
-		t.Fatal("Sync() should fail when server is down")
+	if err := fetcher.Sync(ctx); err != nil {
+		t.Fatalf("seed Sync() failed: %v", err)
 	}
-	if !strings.Contains(fmt.Sprintf("%v", err), "Hint") {
+
+	loadedBefore, err := fetcher.LoadCache()
+	if err != nil || loadedBefore == nil {
+		t.Fatalf("seed cache load failed: err=%v index=%v", err, loadedBefore)
+	}
+	if len(loadedBefore.Entries) != 2 {
+		t.Fatalf("seed cache should contain 2 entries, got %d", len(loadedBefore.Entries))
+	}
+
+	upstream.Close()
+
+	if err := fetcher.Sync(ctx); err == nil {
+		t.Fatal("expected Sync() to fail after server is taken down")
+	} else if !strings.Contains(err.Error(), "Hint") {
 		t.Errorf("error should contain retry guidance, got: %v", err)
 	}
 
-	indexPath := filepath.Join(cacheDir, "registry", "index.json")
-	if _, err := os.Stat(indexPath); os.IsNotExist(err) {
-		t.Log("cache does not exist yet (first sync failed — expected)")
+	loadedAfter, err := fetcher.LoadCache()
+	if err != nil {
+		t.Fatalf("post-failure LoadCache failed: %v", err)
+	}
+	if loadedAfter == nil {
+		t.Fatal("cache must survive a failed Sync; got nil")
+	}
+	if len(loadedAfter.Entries) != 2 {
+		t.Errorf("preserved cache must keep all %d entries, got %d", 2, len(loadedAfter.Entries))
 	}
 }
 
@@ -212,27 +231,186 @@ func TestFeedFetcher_Sync_EmptyBody(t *testing.T) {
 
 func TestFeedFetcher_StartPeriodicRefresh(t *testing.T) {
 	cacheDir := t.TempDir()
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	fetcher := NewFeedFetcher(logger, cacheDir)
 
-	callCount := 0
+	var (
+		mu        sync.Mutex
+		callCount int
+	)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		callCount++
+		mu.Unlock()
 		fmt.Fprintln(w, `{"name":"github","description":"GitHub API"}`)
 	}))
 	defer ts.Close()
 
 	fetcher.WithURL(ts.URL)
-	fetcher.WithInterval(100 * time.Millisecond)
+	fetcher.WithInterval(50 * time.Millisecond)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
-	defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
 	fetcher.StartPeriodicRefresh(ctx)
 
-	<-ctx.Done()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		cc := callCount
+		mu.Unlock()
+		if cc >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	mu.Lock()
+	cc := callCount
+	mu.Unlock()
+	if cc < 2 {
+		t.Fatalf("expected at least 2 sync calls, got %d", cc)
+	}
 
-	if callCount < 2 {
-		t.Errorf("expected at least 2 sync calls, got %d", callCount)
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		fetcher.WaitRefreshDone()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartPeriodicRefresh goroutine did not exit within 2s of ctx cancel")
+	}
+}
+
+func TestFeedFetcher_Sync_MalformedLine_SkipsAndContinues(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"name":"github","description":"GitHub API"}`)
+		fmt.Fprintln(w, `{not valid json`)
+		fmt.Fprintln(w, `{"name":"slack","description":"Slack API"}`)
+		fmt.Fprintln(w, ``)
+	}))
+	defer ts.Close()
+
+	fetcher.WithURL(ts.URL)
+	if err := fetcher.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync() failed: %v", err)
+	}
+
+	loaded, err := fetcher.LoadCache()
+	if err != nil || loaded == nil {
+		t.Fatalf("LoadCache: err=%v index=%v", err, loaded)
+	}
+	if len(loaded.Entries) != 2 {
+		t.Errorf("expected 2 valid entries (malformed skipped), got %d", len(loaded.Entries))
+	}
+}
+
+func TestFeedFetcher_StoreIsAtomic(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	ts := newTestRegistryServer(t, []RegistryFeedEntry{{Name: "github"}})
+	defer ts.Close()
+	fetcher.WithURL(ts.URL)
+
+	if err := fetcher.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync() failed: %v", err)
+	}
+
+	tmpPath := filepath.Join(fetcher.RegistryDir(), "index.json.tmp")
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("expected no leftover .tmp file after a clean Sync, got err=%v", err)
+	}
+
+	indexPath := fetcher.IndexPath()
+	if _, err := os.Stat(indexPath); err != nil {
+		t.Errorf("index.json should exist after Sync: %v", err)
+	}
+}
+
+func TestFeedFetcher_CacheStaleInfo_FutureTimestamp(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	if err := os.MkdirAll(filepath.Join(cacheDir, "registry"), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	future := FeedIndex{
+		SyncedAt: time.Now().Add(48 * time.Hour),
+		Entries:  []RegistryFeedEntry{{Name: "github"}},
+	}
+	data, _ := json.MarshalIndent(future, "", "  ")
+	if err := os.WriteFile(filepath.Join(cacheDir, "registry", "index.json"), data, 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	notice := fetcher.CacheStaleInfo()
+	if !strings.Contains(notice, "invalid") {
+		t.Errorf("expected notice about invalid timestamp, got: %q", notice)
+	}
+}
+
+func TestFeedFetcher_CacheStaleInfo_CorruptFile(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	if err := os.MkdirAll(filepath.Join(cacheDir, "registry"), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "registry", "index.json"), []byte("{not json"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	notice := fetcher.CacheStaleInfo()
+	if notice == "" {
+		t.Fatal("expected a notice for corrupt cache")
+	}
+	if !strings.Contains(notice, "leanproxy marketplace sync") {
+		t.Errorf("expected notice to suggest sync, got: %q", notice)
+	}
+}
+
+func TestFeedFetcher_CacheAge_ZeroSyncedAt(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	if err := os.MkdirAll(filepath.Join(cacheDir, "registry"), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	empty := FeedIndex{Entries: []RegistryFeedEntry{{Name: "github"}}}
+	data, _ := json.MarshalIndent(empty, "", "  ")
+	if err := os.WriteFile(filepath.Join(cacheDir, "registry", "index.json"), data, 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	age, err := fetcher.CacheAge()
+	if err != nil {
+		t.Fatalf("CacheAge: %v", err)
+	}
+	if age != 0 {
+		t.Errorf("zero SyncedAt should yield zero age, got %v", age)
+	}
+}
+
+func TestLeanProxyDir(t *testing.T) {
+	dir, err := LeanProxyDir()
+	if err != nil {
+		t.Fatalf("LeanProxyDir: %v", err)
+	}
+	if dir == "" {
+		t.Fatal("LeanProxyDir returned empty string")
+	}
+	if !strings.HasSuffix(dir, ".leanproxy") {
+		t.Errorf("expected path to end with .leanproxy, got %q", dir)
 	}
 }
 

--- a/pkg/registry/feed_test.go
+++ b/pkg/registry/feed_test.go
@@ -1,0 +1,251 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFeedFetcher_Sync_Success(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	entries := []RegistryFeedEntry{
+		{Name: "github", Description: "GitHub API", URL: "https://github.com/mcp", Transport: "stdio"},
+		{Name: "slack", Description: "Slack API", URL: "https://slack.com/mcp", Transport: "http"},
+		{Name: "postgres", Description: "PostgreSQL", URL: "https://postgres.com/mcp", Transport: "stdio"},
+	}
+	ts := newTestRegistryServer(t, entries)
+	defer ts.Close()
+
+	fetcher.WithURL(ts.URL)
+
+	ctx := context.Background()
+	if err := fetcher.Sync(ctx); err != nil {
+		t.Fatalf("Sync() failed: %v", err)
+	}
+
+	indexPath := filepath.Join(cacheDir, "registry", "index.json")
+	if _, err := os.Stat(indexPath); os.IsNotExist(err) {
+		t.Fatalf("index.json not created at %s", indexPath)
+	}
+
+	loaded, err := fetcher.LoadCache()
+	if err != nil {
+		t.Fatalf("LoadCache() failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("LoadCache() returned nil")
+	}
+	if loaded.SyncedAt.IsZero() {
+		t.Error("SyncedAt is zero")
+	}
+	if len(loaded.Entries) != 3 {
+		t.Errorf("entries count = %d, want 3", len(loaded.Entries))
+	}
+	if loaded.Entries[0].Name != "github" {
+		t.Errorf("first entry name = %s, want github", loaded.Entries[0].Name)
+	}
+}
+
+func TestFeedFetcher_Sync_NetworkError_PreservesCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	entries := []RegistryFeedEntry{
+		{Name: "github", Description: "GitHub API"},
+	}
+	ts := newTestRegistryServer(t, entries)
+	ts.Close()
+
+	fetcher.WithURL(ts.URL)
+
+	ctx := context.Background()
+	err := fetcher.Sync(ctx)
+	if err == nil {
+		t.Fatal("Sync() should fail when server is down")
+	}
+	if !strings.Contains(fmt.Sprintf("%v", err), "Hint") {
+		t.Errorf("error should contain retry guidance, got: %v", err)
+	}
+
+	indexPath := filepath.Join(cacheDir, "registry", "index.json")
+	if _, err := os.Stat(indexPath); os.IsNotExist(err) {
+		t.Log("cache does not exist yet (first sync failed — expected)")
+	}
+}
+
+func TestFeedFetcher_StaleCacheNotice(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	os.MkdirAll(filepath.Join(cacheDir, "registry"), 0700)
+
+	staleIndex := FeedIndex{
+		SyncedAt: time.Now().Add(-48 * time.Hour),
+		Entries:  []RegistryFeedEntry{{Name: "github"}},
+	}
+	data, _ := json.MarshalIndent(staleIndex, "", "  ")
+	os.WriteFile(filepath.Join(cacheDir, "registry", "index.json"), data, 0600)
+
+	notice := fetcher.CacheStaleInfo()
+	if notice == "" {
+		t.Fatal("CacheStaleInfo() returned empty for stale cache")
+	}
+	if !strings.Contains(notice, "leanproxy marketplace sync") {
+		t.Errorf("notice should suggest sync command, got: %s", notice)
+	}
+	if !strings.Contains(notice, "48") {
+		t.Errorf("notice should mention age in hours, got: %s", notice)
+	}
+}
+
+func TestFeedFetcher_FreshCache_NoNotice(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	os.MkdirAll(filepath.Join(cacheDir, "registry"), 0700)
+
+	freshIndex := FeedIndex{
+		SyncedAt: time.Now().Add(-1 * time.Hour),
+		Entries:  []RegistryFeedEntry{{Name: "github"}},
+	}
+	data, _ := json.MarshalIndent(freshIndex, "", "  ")
+	os.WriteFile(filepath.Join(cacheDir, "registry", "index.json"), data, 0600)
+
+	notice := fetcher.CacheStaleInfo()
+	if notice != "" {
+		t.Errorf("expected no notice for fresh cache, got: %s", notice)
+	}
+}
+
+func TestFeedFetcher_NoCache_NoNotice(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	notice := fetcher.CacheStaleInfo()
+	if notice != "" {
+		t.Errorf("expected no notice for missing cache, got: %s", notice)
+	}
+}
+
+func TestFeedFetcher_Sync_HTTPError(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	fetcher.WithURL(ts.URL)
+
+	ctx := context.Background()
+	err := fetcher.Sync(ctx)
+	if err == nil {
+		t.Fatal("Sync() should fail on HTTP 503")
+	}
+	if !strings.Contains(fmt.Sprintf("%v", err), "503") {
+		t.Errorf("error should mention HTTP status, got: %v", err)
+	}
+	if !strings.Contains(fmt.Sprintf("%v", err), "Hint") {
+		t.Errorf("error should contain retry guidance, got: %v", err)
+	}
+}
+
+func TestFeedFetcher_LoadCache_MissingFile(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	index, err := fetcher.LoadCache()
+	if err != nil {
+		t.Fatalf("LoadCache() on missing dir: %v", err)
+	}
+	if index != nil {
+		t.Error("expected nil index for missing file")
+	}
+}
+
+func TestFeedFetcher_Sync_EmptyBody(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	fetcher.WithURL(ts.URL)
+
+	ctx := context.Background()
+	if err := fetcher.Sync(ctx); err != nil {
+		t.Fatalf("Sync() with empty body: %v", err)
+	}
+
+	loaded, err := fetcher.LoadCache()
+	if err != nil {
+		t.Fatalf("LoadCache() failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("LoadCache() returned nil")
+	}
+	if len(loaded.Entries) != 0 {
+		t.Errorf("expected 0 entries for empty body, got %d", len(loaded.Entries))
+	}
+}
+
+func TestFeedFetcher_StartPeriodicRefresh(t *testing.T) {
+	cacheDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	fetcher := NewFeedFetcher(logger, cacheDir)
+
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		fmt.Fprintln(w, `{"name":"github","description":"GitHub API"}`)
+	}))
+	defer ts.Close()
+
+	fetcher.WithURL(ts.URL)
+	fetcher.WithInterval(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
+	defer cancel()
+	fetcher.StartPeriodicRefresh(ctx)
+
+	<-ctx.Done()
+
+	if callCount < 2 {
+		t.Errorf("expected at least 2 sync calls, got %d", callCount)
+	}
+}
+
+func newTestRegistryServer(t *testing.T, entries []RegistryFeedEntry) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, entry := range entries {
+			data, err := json.Marshal(entry)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprintln(w, string(data))
+		}
+	}))
+}


### PR DESCRIPTION
## Summary

Implements **Story 11.1: Subscribe to the MCP Registry feed**, allowing users to fetch and cache the public MCP Registry index locally.

## Acceptance Criteria

### AC1: `leanproxy marketplace sync` downloads to `~/.leanproxy/registry/index.json`
- **`cmd/marketplace.go`** — New CLI command `leanproxy marketplace sync` that calls `FeedFetcher.Sync()`
- **`pkg/registry/feed.go`** — `Sync()` performs HTTP GET + JSONL parse, stores to `~/.leanproxy/registry/index.json` with timestamp

### AC2: Network failure preserves cache + retry guidance
- **`pkg/registry/feed.go:74-82`** — Network errors wrapped with `fmt.Errorf %w` and `Hint:` guidance to retry with `leanproxy marketplace sync`
- **`pkg/registry/feed.go:84-88`** — HTTP status errors also include retry guidance
- Existing cache is preserved on failure (only overwritten on successful sync)

### AC3: Cache >24h on startup logs notice (NFR11)
- **`cmd/serve.go`** — `checkRegistryCacheStale()` function runs as a goroutine at startup (async, non-blocking)
- **`pkg/registry/feed.go`** — `CacheStaleInfo()` returns a notice if cache is >24h old with suggestion to run `leanproxy marketplace sync`

## Files Changed

### New
| File | Description |
|------|-------------|
| `pkg/registry/feed.go` | FeedFetcher struct: Sync, LoadCache, CacheAge, CacheStaleInfo, StartPeriodicRefresh; RegistryFeedEntry and FeedIndex types; LeanProxyDir helper |
| `pkg/registry/feed_test.go` | 9 tests: sync success, network error preserves cache, HTTP error, stale cache notice, fresh cache no notice, no cache no notice, empty body, periodic refresh |
| `cmd/marketplace.go` | `leanproxy marketplace sync` CLI command |
| `cmd/marketplace_test.go` | 3 tests: subcommand structure, help output |

### Modified
| File | Description |
|------|-------------|
| `cmd/serve.go` | Added `checkRegistryCacheStale()` goroutine called on startup |

## Testing

- `go test ./pkg/registry/ -run TestFeed -v` — 9/9 passed
- `go test ./cmd/ -run TestMarketplace -v` — 3/3 passed
- `go build ./...` — clean build