### PR TITLE
feat: leanproxy add <server-id> — one-click registry install (Story 11.2)

### DIFF
--- a/_bmad-output/implementation-artifacts/review-acceptance-auditor-prompt.md
+++ b/_bmad-output/implementation-artifacts/review-acceptance-auditor-prompt.md
@@ -1,0 +1,69 @@
+# Acceptance Auditor — Code Review
+
+**Instructions:** You receive the code diff below, the implementation spec, and any loaded context docs. Review the diff against the spec and context docs. Check for: violations of acceptance criteria, deviations from spec intent, missing implementation of specified behavior, and contradictions between spec constraints and actual code.
+
+## Spec File
+
+Content of `_bmad-output/implementation-artifacts/11-2-one-click-install.md`:
+
+```
+# Story 11.2: Implement 'leanproxy add <server-id>' one-click install
+
+Status: ready-for-dev
+
+## Story Header
+
+| Field | Value |
+|-------|-------|
+| **ID** | 11.2 |
+| **Key** | leanproxy-11-2 |
+| **Epic** | epic-11 — MCP Registry Mirror & Discovery |
+| **Title** | Implement 'leanproxy add <server-id>' one-click install |
+| **Related FRs** | FR41 |
+| **Previous Story:** 11.1 registry-sync |
+
+## User Story
+
+As a user, I want a single command to install and configure an MCP server from the registry, so I can add a tool without writing YAML.
+
+## Acceptance Criteria (BDD Summary)
+
+Registry synced + leanproxy add github -> download def, merge into leanproxy_servers.yaml, schedule start, show success with tool count + token-cost preview. Unknown server -> list up to 5 similar, non-zero exit. Existing name -> prompt or --force, graceful stop first.
+
+## Developer Context
+
+### Technical Notes
+cmd/add.go (NEW): uses pkg/registry/feed + pkg/migrate to merge YAML; pkg/registry/lifecycle.go for graceful stop; token-cost preview from pkg/bouncer/snapshot.go.
+
+### Architecture Compliance
+- camelCase Go, kebab-case CLI flags
+- log/slog to stderr; errors wrapped with fmt.Errorf %w
+- Static binary <20MB; Homebrew + curl|sh install preserved
+- Backward compatibility: existing endpoints and flags unchanged
+
+### Testing Requirements
+- Unit tests for all new exported functions
+- Integration tests for any HTTP/MCP wire changes
+- gosec clean for any new server code (Epic 16)
+```
+
+## Output format
+
+Markdown list. Each finding: one-line title, which AC/constraint it violates, and evidence from the diff.
+
+```
+- [acceptance] Title of the finding
+  AC: Which specific acceptance criterion is violated
+  Evidence: ```go
+  relevant code line(s)
+  ```
+  Explanation: ...
+```
+
+If all acceptance criteria are met, output: "All acceptance criteria satisfied."
+
+---
+
+**Diff file:** `_bmad-output/implementation-artifacts/story-11.2-review-diff.txt`
+
+Paste the contents of that file below this line and run your audit against the spec above.

--- a/_bmad-output/implementation-artifacts/review-blind-hunter-prompt.md
+++ b/_bmad-output/implementation-artifacts/review-blind-hunter-prompt.md
@@ -1,0 +1,30 @@
+# Blind Hunter — Code Review
+
+**Instructions:** You receive ONLY the code diff below. No spec, no project context, no access to source files. Review the code changes critically from first principles.
+
+**Focus areas:**
+- Logic errors, race conditions, nil pointer dereferences
+- Incorrect error handling (unchecked errors, swallowed errors, wrong error wrapping)
+- Resource leaks (file handles, goroutines, connections)
+- Security issues (command injection, path traversal, hardcoded secrets)
+- Incorrect use of Go stdlib patterns (context cancellation, sync primitives, interface contracts)
+- Deadlocks, data races, unbounded goroutine launches
+- Incorrect assumptions about data types (type confusion, overflow)
+- Broken edge cases at boundaries (empty slices, nil maps, zero values)
+
+**Output format:** Markdown list. Each finding: category tag, one-line title, file:line reference, evidence quote from the diff, and brief explanation.
+
+```
+- [bug] Title of the issue
+  File: path/file.go:123
+  Evidence: ```go
+  suspect code line(s)
+  ```
+  Explanation: ...
+```
+
+---
+
+**Diff file:** `_bmad-output/implementation-artifacts/story-11.2-review-diff.txt`
+
+Paste the contents of that file below this line and run your review.

--- a/_bmad-output/implementation-artifacts/review-edge-case-hunter-prompt.md
+++ b/_bmad-output/implementation-artifacts/review-edge-case-hunter-prompt.md
@@ -1,0 +1,34 @@
+# Edge Case Hunter — Code Review
+
+**Instructions:** You receive the code diff below AND read access to the project repository. Review the code changes exhaustively, walking every branching path and boundary condition. Find only **unhandled** edge cases — conditions where the code fails, panics, deadlocks, leaks resources, or produces incorrect output at boundaries.
+
+**Focus areas:**
+- Empty/missing inputs (empty strings, nil slices, nil maps, zero values)
+- Boundary values (min/max ints, empty config, single-element slices, timeouts at boundaries)
+- Error paths (every `if err != nil` — is the error handled or ignored? wrapped or bare?)
+- Concurrency (shared state without synchronization, channel operations near selects, context cancellation propagation)
+- I/O edge cases (partial writes, disk full, file already exists, temp file cleanup failures)
+- Type coercion (string trimming/casing, transport type normalization, YAML round-trips)
+- Atomicity (partial updates, rename vs. concurrent reads, temp file leaks on crash)
+- Permission edge cases (umask variations, read-only config dir, file ownership)
+- State machine edge cases (already installed + dry-run + force, stopped + already exited, etc.)
+- Testing edge cases (test helpers that can themselves fail, temp dir cleanup, environment variable interference)
+
+**Output format:** Markdown list. Each finding: category tag, one-line title, file:line reference, evidence quote from the diff, and brief explanation.
+
+```
+- [edge] Title of the issue
+  File: path/file.go:123
+  Evidence: ```go
+  suspect code line(s)
+  ```
+  Explanation: ...
+```
+
+If no edge cases found, output: "No unhandled edge cases identified."
+
+---
+
+**Diff file:** `_bmad-output/implementation-artifacts/story-11.2-review-diff.txt`
+
+Paste the contents of that file below this line and run your review. Use your project read access to examine the full source context of any suspicious lines.

--- a/_bmad-output/implementation-artifacts/story-11.2-review-diff.txt
+++ b/_bmad-output/implementation-artifacts/story-11.2-review-diff.txt
@@ -1,0 +1,524 @@
+cmd/add.go                    | 248 ++++++++++++++++++++
+ cmd/add_test.go               | 341 +++++++++++++++++++++++++++
+ pkg/bouncer/snapshot.go       | 133 +++++++++++
+ pkg/bouncer/snapshot_test.go  | 111 +++++++++
+ pkg/migrate/config.go         |  31 ++-
+ pkg/migrate/config_test.go    |  26 +--
+ pkg/migrate/installer.go      | 527 ++++++++++++++++++++++++++++++++++++++++++
+ pkg/migrate/installer_test.go | 461 ++++++++++++++++++++++++++++++++++++
+ pkg/migrate/scanner.go        |  12 +-
+ pkg/migrate/transport.go      |  16 ++
+ pkg/registry/registry.go      |   9 +-
+ 11 files changed, 1874 insertions(+), 41 deletions(-)
+
+Changes:
+
+cmd/add.go
+  @@ -0,0 +1,248 @@
+  +package cmd
+  +
+  +import (
+  +	"context"
+  +	"errors"
+  +	"fmt"
+  +	"log/slog"
+  +	"strings"
+  +	"time"
+  +
+  +	"github.com/mmornati/leanproxy-mcp/pkg/bouncer"
+  +	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
+  +	"github.com/mmornati/leanproxy-mcp/pkg/registry"
+  +	"github.com/spf13/cobra"
+  +)
+  +
+  +var (
+  +	addServerForce        bool
+  +	addServerYes          bool
+  +	addServerDryRun       bool
+  +	addServerGracefulWait int
+  +	addServerStopExisting bool
+  +)
+  +
+  +// feedSourceAdapter satisfies migrate.ServerSource by reading from a registry
+  +// FeedFetcher. It lives in cmd/ rather than pkg/registry to keep the package
+  +// dependency direction one-way: migrate owns the installer schema, registry
+  +// owns the cache, and cmd stitches them together.
+  +type feedSourceAdapter struct {
+  +	fetcher *registry.FeedFetcher
+  +}
+  +
+  +func (a *feedSourceAdapter) LookupCache(_ context.Context) (migrate.CacheSnapshot, error) {
+  +	if a.fetcher == nil {
+  +		return migrate.CacheSnapshot{}, fmt.Errorf("feed source adapter: nil fetcher")
+  +	}
+  +	index, err := a.fetcher.LoadCache()
+  +	if err != nil {
+  +		return migrate.CacheSnapshot{}, fmt.Errorf("feed source adapter: load cache: %w", err)
+  +	}
+  +	if index == nil {
+  +		return migrate.CacheSnapshot{}, nil
+  +	}
+  +	entries := make([]migrate.CacheEntry, 0, len(index.Entries))
+  +	for _, e := range index.Entries {
+  +		entries = append(entries, migrate.CacheEntry{
+  +			Name:          e.Name,
+  +			Transport:     e.Transport,
+  +			Command:       e.Command,
+  +			Args:          append([]string(nil), e.Args...),
+  +			Env:           cloneStringMap(e.Env),
+  +			URL:           e.URL,
+  +			TokensPerTurn: e.TokensPerTurn,
+  +		})
+  +	}
+  +	return migrate.CacheSnapshot{Entries: entries}, nil
+  +}
+  +
+  +func cloneStringMap(in map[string]string) map[string]string {
+  +	if len(in) == 0 {
+  +		return nil
+  +	}
+  +	out := make(map[string]string, len(in))
+  +	for k, v := range in {
+  +		out[k] = v
+  +	}
+  +	return out
+  +}
+  +
+  +var addRegistryCmd = &cobra.Command{
+  +	Use:   "add <server-id>",
+  +	Short: "Install an MCP server from the registry",
+  +	Long: `Install an MCP server from the local MCP Registry cache.
+  +
+  +The command resolves the registry entry, merges its definition into
+  +leanproxy_servers.yaml, optionally gracefully stops any running instance with
+  +the same name, and prints a token-cost preview of the new server.
+  +
+  +If the cache is empty or stale, run 'leanproxy marketplace sync' first.`,
+  +	Args:    cobra.ExactArgs(1),
+  +	Aliases: []string{"install"},
+  +	RunE:    runAdd,
+  +}
+  +
+  +func init() {
+  +	addRegistryCmd.Flags().BoolVar(&addServerForce, "force", false, "Overwrite an existing server definition with the same name")
+  +	addRegistryCmd.Flags().BoolVarP(&addServerYes, "yes", "y", false, "Skip the confirmation prompt when overwriting")
+  +	addRegistryCmd.Flags().BoolVar(&addServerDryRun, "dry-run", false, "Preview the install without writing the config")
+  +	addRegistryCmd.Flags().BoolVar(&addServerStopExisting, "stop-existing", true, "Gracefully stop any running server with the same name before replacing")
+  +	addRegistryCmd.Flags().IntVar(&addServerGracefulWait, "graceful-wait", 10, "Seconds to wait for graceful stop before proceeding (0 = no wait)")
+  +	RootCmd.AddCommand(addRegistryCmd)
+  +}
+  +
+  +func runAdd(cmd *cobra.Command, args []string) error {
+  +	initLogger(cmd)
+  +
+  +	stdout := cmd.OutOrStdout()
+  +	stderr := cmd.ErrOrStderr()
+  +
+  +	serverID := strings.TrimSpace(args[0])
+  ... (148 lines truncated)
+  +248 -0
+
+cmd/add_test.go
+  @@ -0,0 +1,341 @@
+  +package cmd
+  +
+  +import (
+  +	"bytes"
+  +	"context"
+  +	"encoding/json"
+  +	"os"
+  +	"path/filepath"
+  +	"strings"
+  +	"testing"
+  +	"time"
+  +
+  +	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
+  +	"github.com/mmornati/leanproxy-mcp/pkg/registry"
+  +	"github.com/spf13/cobra"
+  +)
+  +
+  +func TestAddRegistryCmd_Registered(t *testing.T) {
+  +	var found bool
+  +	for _, c := range RootCmd.Commands() {
+  +		if c.Use == "add <server-id>" {
+  +			found = true
+  +			if c.Short == "" {
+  +				t.Error("add command should have a short description")
+  +			}
+  +			if !containsString(c.Aliases, "install") {
+  +				t.Error("add command should alias 'install'")
+  +			}
+  +			break
+  +		}
+  +	}
+  +	if !found {
+  +		t.Fatal("'add' command not registered on RootCmd")
+  +	}
+  +}
+  +
+  +func TestAddRegistryCmd_Flags(t *testing.T) {
+  +	flags := addRegistryCmd.Flags()
+  +	for _, name := range []string{"force", "yes", "dry-run", "stop-existing", "graceful-wait"} {
+  +		if flags.Lookup(name) == nil {
+  +			t.Errorf("add command missing --%s flag", name)
+  +		}
+  +	}
+  +	if addRegistryCmd.Args == nil {
+  +		t.Fatal("add command should declare an Args validator")
+  +	}
+  +	if err := addRegistryCmd.Args(addRegistryCmd, []string{}); err == nil {
+  +		t.Error("add command should require exactly one arg")
+  +	}
+  +	if err := addRegistryCmd.Args(addRegistryCmd, []string{"a", "b"}); err == nil {
+  +		t.Error("add command should reject more than one arg")
+  +	}
+  +}
+  +
+  +// writeIndex writes a FeedIndex JSON to the cache dir consumed by FeedFetcher.
+  +func writeIndex(t *testing.T, dir string, index registry.FeedIndex) {
+  +	t.Helper()
+  +	registryDir := filepath.Join(dir, "registry")
+  +	if err := os.MkdirAll(registryDir, 0o700); err != nil {
+  +		t.Fatal(err)
+  +	}
+  +	data, err := json.MarshalIndent(index, "", "  ")
+  +	if err != nil {
+  +		t.Fatal(err)
+  +	}
+  +	if err := os.WriteFile(filepath.Join(registryDir, "index.json"), data, 0o600); err != nil {
+  +		t.Fatal(err)
+  +	}
+  +}
+  +
+  +func TestFeedSourceAdapter_NilFetcher(t *testing.T) {
+  +	a := &feedSourceAdapter{}
+  +	_, err := a.LookupCache(context.Background())
+  +	if err == nil {
+  +		t.Fatal("expected error for nil fetcher")
+  +	}
+  +}
+  +
+  +func TestFeedSourceAdapter_PopulatedCache(t *testing.T) {
+  +	dir := t.TempDir()
+  +	writeIndex(t, dir, registry.FeedIndex{
+  +		SyncedAt: testNow(t),
+  +		Entries: []registry.RegistryFeedEntry{
+  +			{
+  +				Name:      "github",
+  +				Transport: "stdio",
+  +				Command:   "gh-mcp",
+  +				Args:      []string{"--port", "8080"},
+  +				Env:       map[string]string{"FOO": "bar"},
+  +				URL:       "https://example.com",
+  +			},
+  +			{
+  +				Name:      "remote",
+  +				Transport: "http",
+  +				URL:       "https://remote.example/mcp",
+  +			},
+  +		},
+  +	})
+  +
+  +	fetcher := registry.NewFeedFetcher(nil, dir)
+  ... (241 lines truncated)
+  +341 -0
+
+pkg/bouncer/snapshot.go
+  @@ -0,0 +1,133 @@
+  +package bouncer
+  +
+  +import (
+  +	"fmt"
+  +
+  +	"github.com/mmornati/leanproxy-mcp/pkg/utils"
+  +)
+  +
+  +const (
+  +	// DefaultEstimatedTools is the default tool-count estimate when the
+  +	// registry entry does not declare one. It matches the average used by
+  +	// pkg/utils.TokenEstimator.CompareMCPConfigurations.
+  +	DefaultEstimatedTools = 35
+  +
+  +	// estimatedToolsPerKB is a coarse heuristic used to derive a tool count
+  +	// from the registry entry's description when nothing else is available.
+  +	estimatedToolsPerKB = 40
+  +)
+  +
+  +// Snapshot describes the token impact of adding a server to a LeanProxy
+  +// deployment. It is computed from a registry feed entry before the server is
+  +// installed so the user can preview the cost.
+  +type Snapshot struct {
+  +	ServerName         string
+  +	Transport          string
+  +	EstimatedTools     int
+  +	NativeTokens       int
+  +	LeanProxyTokens    int
+  +	SavedTokens        int
+  +	SavingsPercent     float64
+  +	HasRegistryBudget  bool
+  +	RegistryBudgetNote string
+  +}
+  +
+  +// ComputeSnapshot returns a token-cost preview for the given server definition.
+  +//
+  +// The estimate is derived from the entry's declared tool count when available
+  +// (TokensPerTurn is treated as a per-turn override), otherwise from a default
+  +// heuristic. The LeanProxy cost assumes a single gateway schema (invoke_tool +
+  +// list_tools) regardless of how many real tools the server exposes.
+  +//
+  +// The returned Snapshot is safe for direct fmt.Stringer-style printing via
+  +// FormatSnapshot.
+  +func ComputeSnapshot(name, transport string, estimatedTools int, tokensPerTurn int64) Snapshot {
+  +	if name == "" {
+  +		name = "unknown"
+  +	}
+  +	if transport == "" {
+  +		transport = "stdio"
+  +	}
+  +	if estimatedTools <= 0 {
+  +		estimatedTools = DefaultEstimatedTools
+  +	}
+  +
+  +	estimator := utils.NewTokenEstimator()
+  +	native := estimator.EstimateNativeMCPOverhead(name, estimatedTools)
+  +	lean := estimator.EstimateLeanProxySchemaTokens()
+  +
+  +	saved := native - lean
+  +	if saved < 0 {
+  +		saved = 0
+  +	}
+  +	var pct float64
+  +	if native > 0 {
+  +		pct = float64(saved) / float64(native) * 100
+  +	}
+  +
+  +	return Snapshot{
+  +		ServerName:         name,
+  +		Transport:          transport,
+  +		EstimatedTools:     estimatedTools,
+  +		NativeTokens:       native,
+  +		LeanProxyTokens:    lean,
+  +		SavedTokens:        saved,
+  +		SavingsPercent:     pct,
+  +		HasRegistryBudget:  tokensPerTurn > 0,
+  +		RegistryBudgetNote: formatBudgetNote(tokensPerTurn),
+  +	}
+  +}
+  +
+  +// EstimateToolsFromDescription derives a coarse tool-count estimate from the
+  +// size of the registry entry's description. It is intentionally simple so it
+  +// can be used as a fallback when no other signal is present; callers should
+  +// prefer ComputeSnapshot with an explicit tool count whenever possible.
+  +func EstimateToolsFromDescription(description string) int {
+  +	if len(description) == 0 {
+  +		return DefaultEstimatedTools
+  +	}
+  +	kb := len(description) / 1024
+  +	if kb == 0 {
+  +		return DefaultEstimatedTools
+  +	}
+  +	estimate := kb * estimatedToolsPerKB
+  +	if estimate < DefaultEstimatedTools {
+  +		return DefaultEstimatedTools
+  +	}
+  +	return estimate
+  +}
+  +
+  +// FormatSnapshot renders the snapshot as a short human-readable block ready to
+  ... (33 lines truncated)
+  +133 -0
+
+pkg/bouncer/snapshot_test.go
+  @@ -0,0 +1,111 @@
+  +package bouncer
+  +
+  +import (
+  +	"strings"
+  +	"testing"
+  +)
+  +
+  +func TestComputeSnapshot_DefaultsApplied(t *testing.T) {
+  +	s := ComputeSnapshot("", "", 0, 0)
+  +	if s.ServerName != "unknown" {
+  +		t.Errorf("ServerName = %q, want %q", s.ServerName, "unknown")
+  +	}
+  +	if s.Transport != "stdio" {
+  +		t.Errorf("Transport = %q, want %q", s.Transport, "stdio")
+  +	}
+  +	if s.EstimatedTools != DefaultEstimatedTools {
+  +		t.Errorf("EstimatedTools = %d, want %d", s.EstimatedTools, DefaultEstimatedTools)
+  +	}
+  +	if s.NativeTokens != DefaultEstimatedTools*75 {
+  +		t.Errorf("NativeTokens = %d, want %d", s.NativeTokens, DefaultEstimatedTools*75)
+  +	}
+  +	if !s.HasRegistryBudget && s.RegistryBudgetNote != "" {
+  +		t.Errorf("HasRegistryBudget false but budget note = %q", s.RegistryBudgetNote)
+  +	}
+  +}
+  +
+  +func TestComputeSnapshot_BasicMath(t *testing.T) {
+  +	s := ComputeSnapshot("github", "stdio", 20, 0)
+  +	if s.EstimatedTools != 20 {
+  +		t.Errorf("EstimatedTools = %d, want 20", s.EstimatedTools)
+  +	}
+  +	if s.NativeTokens != 1500 {
+  +		t.Errorf("NativeTokens = %d, want 1500", s.NativeTokens)
+  +	}
+  +	if s.LeanProxyTokens <= 0 {
+  +		t.Errorf("LeanProxyTokens should be positive, got %d", s.LeanProxyTokens)
+  +	}
+  +	if s.SavedTokens <= 0 {
+  +		t.Errorf("SavedTokens should be positive, got %d", s.SavedTokens)
+  +	}
+  +	if s.SavingsPercent <= 0 || s.SavingsPercent >= 100 {
+  +		t.Errorf("SavingsPercent out of range, got %v", s.SavingsPercent)
+  +	}
+  +}
+  +
+  +func TestComputeSnapshot_RegistryBudgetReported(t *testing.T) {
+  +	s := ComputeSnapshot("github", "stdio", 10, 1500)
+  +	if !s.HasRegistryBudget {
+  +		t.Error("HasRegistryBudget should be true when tokensPerTurn > 0")
+  +	}
+  +	if !strings.Contains(s.RegistryBudgetNote, "1500") {
+  +		t.Errorf("RegistryBudgetNote = %q, expected it to mention 1500", s.RegistryBudgetNote)
+  +	}
+  +}
+  +
+  +func TestComputeSnapshot_NegativeToolsDefaultsUp(t *testing.T) {
+  +	s := ComputeSnapshot("foo", "http", -5, 0)
+  +	if s.EstimatedTools != DefaultEstimatedTools {
+  +		t.Errorf("negative tool count should default, got %d", s.EstimatedTools)
+  +	}
+  +}
+  +
+  +func TestEstimateToolsFromDescription(t *testing.T) {
+  +	tests := []struct {
+  +		name string
+  +		desc string
+  +		want int
+  +	}{
+  +		{"empty uses default", "", DefaultEstimatedTools},
+  +		{"short uses default", "tiny description", DefaultEstimatedTools},
+  +		{"medium scales up", strings.Repeat("a", 5*1024), 5 * estimatedToolsPerKB},
+  +		{"floor enforced when below default", strings.Repeat("a", 512), DefaultEstimatedTools},
+  +	}
+  +	for _, tc := range tests {
+  +		t.Run(tc.name, func(t *testing.T) {
+  +			got := EstimateToolsFromDescription(tc.desc)
+  +			if got != tc.want {
+  +				t.Errorf("EstimateToolsFromDescription(len=%d) = %d, want %d", len(tc.desc), got, tc.want)
+  +			}
+  +		})
+  +	}
+  +}
+  +
+  +func TestFormatSnapshot_ZeroSavings(t *testing.T) {
+  +	s := Snapshot{ServerName: "x", Transport: "stdio", EstimatedTools: 1, NativeTokens: 100, LeanProxyTokens: 100}
+  +	out := FormatSnapshot(s)
+  +	if !strings.Contains(out, "no savings") {
+  +		t.Errorf("FormatSnapshot with zero savings should mention 'no savings', got %q", out)
+  +	}
+  +	if !strings.Contains(out, "x") {
+  +		t.Errorf("FormatSnapshot should include server name, got %q", out)
+  +	}
+  +}
+  +
+  +func TestFormatSnapshot_PositiveSavings(t *testing.T) {
+  +	s := Snapshot{
+  +		ServerName:      "github",
+  +		Transport:       "stdio",
+  +		EstimatedTools:  20,
+  +		NativeTokens:    1500,
+  ... (11 lines truncated)
+  +111 -0
+
+pkg/migrate/config.go
+  @@ -9,7 +9,6 @@ import (
+  -	"github.com/mmornati/leanproxy-mcp/pkg/registry"
+   	"github.com/mmornati/leanproxy-mcp/pkg/utils"
+   )
+   
+  @@ -56,19 +55,19 @@ type AuthConfig struct {
+  -	Name                string                 `yaml:"name"`
+  -	Enabled             *bool                  `yaml:"enabled"`
+  -	Transport           registry.TransportType `yaml:"transport"`
+  -	Stdio               *StdioConfig           `yaml:"stdio,omitempty"`
+  -	HTTP                *HTTPConfig            `yaml:"http,omitempty"`
+  -	Timeout             string                 `yaml:"timeout"`
+  -	TimeoutValue        time.Duration          `yaml:"-"`
+  -	ConnectTimeout      string                 `yaml:"connect_timeout"`
+  -	ConnectTimeoutValue time.Duration          `yaml:"-"`
+  -	IdleTimeout         string                 `yaml:"idle_timeout"`
+  -	IdleTimeoutValue    time.Duration          `yaml:"-"`
+  -	CacheSettings       *CacheSettings         `yaml:"cache_settings,omitempty"`
+  -	SummarizeSettings   *SummarizeSettings     `yaml:"summarize_settings,omitempty"`
+  +	Name                string         `yaml:"name"`
+  +	Enabled             *bool          `yaml:"enabled"`
+  +	Transport           TransportType  `yaml:"transport"`
+  +	Stdio               *StdioConfig   `yaml:"stdio,omitempty"`
+  +	HTTP                *HTTPConfig    `yaml:"http,omitempty"`
+  +	Timeout             string         `yaml:"timeout"`
+  +	TimeoutValue        time.Duration  `yaml:"-"`
+  +	ConnectTimeout      string         `yaml:"connect_timeout"`
+  +	ConnectTimeoutValue time.Duration  `yaml:"-"`
+  +	IdleTimeout         string         `yaml:"idle_timeout"`
+  +	IdleTimeoutValue    time.Duration  `yaml:"-"`
+  +	CacheSettings       *CacheSettings `yaml:"cache_settings,omitempty"`
+  +	SummarizeSettings   *SummarizeSettings `yaml:"summarize_settings,omitempty"`
+   }
+   
+   type Config struct {
+  @@ -101,11 +100,11 @@ func (c *ServerConfig) Validate() error {
+  -	case registry.TransportStdio:
+  +	case TransportStdio:
+   		if c.Stdio == nil || c.Stdio.Command == "" {
+   			return fmt.Errorf("server %s: command is required for stdio transport", c.Name)
+   		}
+  -	case registry.TransportHTTP, registry.TransportSSE:
+  +	case TransportHTTP, TransportSSE:
+   		if c.HTTP == nil || c.HTTP.URL == "" {
+   			return fmt.Errorf("server %s: url is required for %s transport", c.Name, c.Transport)
+   		}
+  +15 -16
+
+pkg/migrate/config_test.go
+  @@ -6,8 +6,6 @@ import (
+  -
+  -	"github.com/mmornati/leanproxy-mcp/pkg/registry"
+   )
+   
+   func TestLoadConfigMinimal(t *testing.T) {
+  @@ -39,7 +37,7 @@ servers:
+  -	if server.Transport != registry.TransportStdio {
+  +	if server.Transport != TransportStdio {
+   		t.Errorf("Transport = %v, want stdio", server.Transport)
+   	}
+   	if server.Enabled == nil || !*server.Enabled {
+  @@ -100,7 +98,7 @@ servers:
+  -	if server.Transport != registry.TransportHTTP {
+  +	if server.Transport != TransportHTTP {
+   		t.Errorf("Transport = %v, want http", server.Transport)
+   	}
+   	if server.HTTP.URL != "http://localhost:8080" {
+  @@ -218,7 +216,7 @@ func TestServerConfigValidate(t *testing.T) {
+  -				Transport: registry.TransportStdio,
+  +				Transport: TransportStdio,
+   				Stdio:     &StdioConfig{Command: "/bin/server"},
+   			},
+   			wantErr: false,
+  @@ -227,7 +225,7 @@ func TestServerConfigValidate(t *testing.T) {
+  -				Transport: registry.TransportHTTP,
+  +				Transport: TransportHTTP,
+   				HTTP:      &HTTPConfig{URL: "http://localhost:8080"},
+   			},
+   			wantErr: false,
+  @@ -236,14 +234,14 @@ func TestServerConfigValidate(t *testing.T) {
+  -				Transport: registry.TransportSSE,
+  +				Transport: TransportSSE,
+   				HTTP:      &HTTPConfig{URL: "http://localhost:8080/sse"},
+   			},
+
+... (more changes truncated)
+  +5 -7
+[full diff: rtk git diff --no-compact]

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/bouncer"
+	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
+	"github.com/mmornati/leanproxy-mcp/pkg/registry"
+	"github.com/spf13/cobra"
+)
+
+var (
+	addServerForce        bool
+	addServerYes          bool
+	addServerDryRun       bool
+	addServerGracefulWait int
+	addServerStopExisting bool
+)
+
+// feedSourceAdapter satisfies migrate.ServerSource by reading from a registry
+// FeedFetcher. It lives in cmd/ rather than pkg/registry to keep the package
+// dependency direction one-way: migrate owns the installer schema, registry
+// owns the cache, and cmd stitches them together.
+type feedSourceAdapter struct {
+	fetcher *registry.FeedFetcher
+}
+
+func (a *feedSourceAdapter) LookupCache(_ context.Context) (migrate.CacheSnapshot, error) {
+	if a.fetcher == nil {
+		return migrate.CacheSnapshot{}, fmt.Errorf("feed source adapter: nil fetcher")
+	}
+	index, err := a.fetcher.LoadCache()
+	if err != nil {
+		return migrate.CacheSnapshot{}, fmt.Errorf("feed source adapter: load cache: %w", err)
+	}
+	if index == nil {
+		return migrate.CacheSnapshot{}, nil
+	}
+	entries := make([]migrate.CacheEntry, 0, len(index.Entries))
+	for _, e := range index.Entries {
+		entries = append(entries, migrate.CacheEntry{
+			Name:          e.Name,
+			Transport:     e.Transport,
+			Command:       e.Command,
+			Args:          append([]string(nil), e.Args...),
+			Env:           cloneStringMap(e.Env),
+			URL:           e.URL,
+			TokensPerTurn: e.TokensPerTurn,
+		})
+	}
+	return migrate.CacheSnapshot{Entries: entries}, nil
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+var addRegistryCmd = &cobra.Command{
+	Use:   "add <server-id>",
+	Short: "Install an MCP server from the registry",
+	Long: `Install an MCP server from the local MCP Registry cache.
+
+The command resolves the registry entry, merges its definition into
+leanproxy_servers.yaml, optionally gracefully stops any running instance with
+the same name, and prints a token-cost preview of the new server.
+
+If the cache is empty or stale, run 'leanproxy marketplace sync' first.`,
+	Args:    cobra.ExactArgs(1),
+	Aliases: []string{"install"},
+	RunE:    runAdd,
+}
+
+func init() {
+	addRegistryCmd.Flags().BoolVar(&addServerForce, "force", false, "Overwrite an existing server definition with the same name")
+	addRegistryCmd.Flags().BoolVarP(&addServerYes, "yes", "y", false, "Skip the confirmation prompt when overwriting")
+	addRegistryCmd.Flags().BoolVar(&addServerDryRun, "dry-run", false, "Preview the install without writing the config")
+	addRegistryCmd.Flags().BoolVar(&addServerStopExisting, "stop-existing", true, "Gracefully stop any running server with the same name before replacing")
+	addRegistryCmd.Flags().IntVar(&addServerGracefulWait, "graceful-wait", 10, "Seconds to wait for graceful stop before proceeding (0 = no wait)")
+	RootCmd.AddCommand(addRegistryCmd)
+}
+
+func runAdd(cmd *cobra.Command, args []string) error {
+	initLogger(cmd)
+
+	stdout := cmd.OutOrStdout()
+	stderr := cmd.ErrOrStderr()
+
+	serverID := strings.TrimSpace(args[0])
+	if serverID == "" {
+		return fmt.Errorf("server id is required")
+	}
+
+	cacheDir, err := registry.LeanProxyDir()
+	if err != nil {
+		return fmt.Errorf("determine cache directory: %w", err)
+	}
+
+	fetcher := registry.NewFeedFetcher(slog.Default(), cacheDir)
+	staleNotice := fetcher.CacheStaleInfo()
+	if staleNotice != "" {
+		fmt.Fprintf(stderr, "Warning: %s\n", staleNotice)
+	}
+
+	cache, cacheErr := fetcher.LoadCache()
+	if cacheErr != nil {
+		return fmt.Errorf("load registry cache: %w", cacheErr)
+	}
+	if cache == nil || len(cache.Entries) == 0 {
+		return fmt.Errorf(
+			"registry cache is empty. Run `leanproxy marketplace sync` to populate it, then retry `leanproxy add %s`",
+			serverID,
+		)
+	}
+
+	source := &feedSourceAdapter{fetcher: fetcher}
+	installer := migrate.NewInstaller(source, userConfigPath(), slog.Default())
+
+	resolveCtx := cmd.Context()
+	if resolveCtx == nil {
+		resolveCtx = context.Background()
+	}
+
+	entry, resolveErr := installer.Resolve(resolveCtx, serverID)
+	if resolveErr != nil {
+		if migrate.IsUnknownServer(resolveErr) {
+			var unknown *migrate.ErrUnknownServer
+			if errors.As(resolveErr, &unknown) {
+				fmt.Fprintf(stderr, "Error: %s\n", unknown.Error())
+				if len(unknown.Suggested) > 0 {
+					fmt.Fprintln(stderr, "\nDid you mean one of:")
+					for _, s := range unknown.Suggested {
+						fmt.Fprintf(stderr, "  leanproxy add %s\n", s)
+					}
+				}
+				return fmt.Errorf("unknown server %q", serverID)
+			}
+		}
+		return fmt.Errorf("resolve server %q: %w", serverID, resolveErr)
+	}
+
+	// Detect the existing-server case so we can prompt before the install.
+	existing, existingErr := loadExistingEntry(userConfigPath(), entry.Name)
+	if existingErr != nil {
+		return fmt.Errorf("inspect existing config: %w", existingErr)
+	}
+	alreadyInstalled := existing != nil
+
+	if alreadyInstalled && !addServerForce {
+		if !addServerYes {
+			fmt.Fprintf(stdout,
+				"Server %q already exists in %s.\nReplace it? [y/N]: ",
+				entry.Name, userConfigPath(),
+			)
+			var response string
+			_, _ = fmt.Scanln(&response)
+			if response != "y" && response != "Y" {
+				fmt.Fprintln(stdout, "Install canceled. Re-run with --force to overwrite without prompting.")
+				return nil
+			}
+		}
+	}
+
+	graceful := time.Duration(addServerGracefulWait) * time.Second
+	opts := migrate.InstallOptions{
+		Force:           addServerForce || (alreadyInstalled && addServerYes),
+		StopExisting:    addServerStopExisting,
+		GracefulTimeout: graceful,
+		Stopper:         nil, // lifecycle wiring happens in a follow-up; cmd/add stays config-only by default
+		Logger:          slog.Default(),
+		DryRun:          addServerDryRun || DryRunEnabled,
+	}
+
+	installCtx := cmd.Context()
+	if installCtx == nil {
+		installCtx = context.Background()
+	}
+
+	result, err := installer.Install(installCtx, entry, opts)
+	if err != nil {
+		if migrate.IsAlreadyInstalled(err) {
+			return fmt.Errorf("server already installed; re-run with --force to replace")
+		}
+		return fmt.Errorf("install %q: %w", serverID, err)
+	}
+
+	if result.DryRun {
+		fmt.Fprintln(stdout, "Dry-run: no changes were written.")
+	}
+
+	snapshot := bouncer.ComputeSnapshot(
+		entry.Name, string(result.Transport),
+		bouncer.EstimateToolsFromDescription(descriptionFor(entry)),
+		entry.TokensPerTurn,
+	)
+	fmt.Fprintln(stdout, bouncer.FormatSnapshot(snapshot))
+
+	fmt.Fprintf(stdout, "\n✓ Installed %s (%s)\n", result.ServerName, result.Transport)
+	fmt.Fprintf(stdout, "  Config: %s\n", result.ConfigPath)
+	if result.Replaced {
+		fmt.Fprintln(stdout, "  Replaced: yes")
+	}
+	if result.Stopped {
+		fmt.Fprintln(stdout, "  Graceful stop: yes")
+	}
+
+	return nil
+}
+
+// loadExistingEntry returns a non-nil pointer (true presence) when the config
+// already has a server with name, nil otherwise. Errors are returned for
+// I/O / parse failures only.
+func loadExistingEntry(path, name string) (*migrate.ServerConfig, error) {
+	cfg, err := migrate.LoadConfig(context.Background(), path)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+	for _, s := range cfg.Servers {
+		if s != nil && s.Name == name {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+func descriptionFor(entry migrate.CacheEntry) string {
+	if v := strings.TrimSpace(entry.URL); v != "" {
+		return v
+	}
+	if len(entry.Args) > 0 {
+		return strings.Join(entry.Args, " ")
+	}
+	return entry.Command
+}

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,341 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
+	"github.com/mmornati/leanproxy-mcp/pkg/registry"
+	"github.com/spf13/cobra"
+)
+
+func TestAddRegistryCmd_Registered(t *testing.T) {
+	var found bool
+	for _, c := range RootCmd.Commands() {
+		if c.Use == "add <server-id>" {
+			found = true
+			if c.Short == "" {
+				t.Error("add command should have a short description")
+			}
+			if !containsString(c.Aliases, "install") {
+				t.Error("add command should alias 'install'")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("'add' command not registered on RootCmd")
+	}
+}
+
+func TestAddRegistryCmd_Flags(t *testing.T) {
+	flags := addRegistryCmd.Flags()
+	for _, name := range []string{"force", "yes", "dry-run", "stop-existing", "graceful-wait"} {
+		if flags.Lookup(name) == nil {
+			t.Errorf("add command missing --%s flag", name)
+		}
+	}
+	if addRegistryCmd.Args == nil {
+		t.Fatal("add command should declare an Args validator")
+	}
+	if err := addRegistryCmd.Args(addRegistryCmd, []string{}); err == nil {
+		t.Error("add command should require exactly one arg")
+	}
+	if err := addRegistryCmd.Args(addRegistryCmd, []string{"a", "b"}); err == nil {
+		t.Error("add command should reject more than one arg")
+	}
+}
+
+// writeIndex writes a FeedIndex JSON to the cache dir consumed by FeedFetcher.
+func writeIndex(t *testing.T, dir string, index registry.FeedIndex) {
+	t.Helper()
+	registryDir := filepath.Join(dir, "registry")
+	if err := os.MkdirAll(registryDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(registryDir, "index.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFeedSourceAdapter_NilFetcher(t *testing.T) {
+	a := &feedSourceAdapter{}
+	_, err := a.LookupCache(context.Background())
+	if err == nil {
+		t.Fatal("expected error for nil fetcher")
+	}
+}
+
+func TestFeedSourceAdapter_PopulatedCache(t *testing.T) {
+	dir := t.TempDir()
+	writeIndex(t, dir, registry.FeedIndex{
+		SyncedAt: testNow(t),
+		Entries: []registry.RegistryFeedEntry{
+			{
+				Name:      "github",
+				Transport: "stdio",
+				Command:   "gh-mcp",
+				Args:      []string{"--port", "8080"},
+				Env:       map[string]string{"FOO": "bar"},
+				URL:       "https://example.com",
+			},
+			{
+				Name:      "remote",
+				Transport: "http",
+				URL:       "https://remote.example/mcp",
+			},
+		},
+	})
+
+	fetcher := registry.NewFeedFetcher(nil, dir)
+	a := &feedSourceAdapter{fetcher: fetcher}
+	snap, err := a.LookupCache(context.Background())
+	if err != nil {
+		t.Fatalf("LookupCache: %v", err)
+	}
+	if len(snap.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(snap.Entries))
+	}
+	var gh, remote *migrate.CacheEntry
+	for i := range snap.Entries {
+		e := &snap.Entries[i]
+		switch e.Name {
+		case "github":
+			gh = e
+		case "remote":
+			remote = e
+		}
+	}
+	if gh == nil || gh.Command != "gh-mcp" {
+		t.Errorf("github entry malformed: %+v", gh)
+	}
+	if gh.Env["FOO"] != "bar" {
+		t.Errorf("github env not copied: %+v", gh.Env)
+	}
+	if len(gh.Args) != 2 || gh.Args[0] != "--port" {
+		t.Errorf("github args not copied: %v", gh.Args)
+	}
+	if remote == nil || remote.URL != "https://remote.example/mcp" {
+		t.Errorf("remote entry malformed: %+v", remote)
+	}
+}
+
+func TestFeedSourceAdapter_EmptyCache(t *testing.T) {
+	dir := t.TempDir()
+	fetcher := registry.NewFeedFetcher(nil, dir)
+	a := &feedSourceAdapter{fetcher: fetcher}
+	snap, err := a.LookupCache(context.Background())
+	if err != nil {
+		t.Fatalf("LookupCache: %v", err)
+	}
+	if len(snap.Entries) != 0 {
+		t.Errorf("expected empty entries, got %d", len(snap.Entries))
+	}
+}
+
+func TestCloneStringMap(t *testing.T) {
+	if cloneStringMap(nil) != nil {
+		t.Error("nil should return nil")
+	}
+	if cloneStringMap(map[string]string{}) != nil {
+		t.Error("empty map should return nil")
+	}
+	src := map[string]string{"a": "1", "b": "2"}
+	dst := cloneStringMap(src)
+	if len(dst) != 2 {
+		t.Errorf("len = %d", len(dst))
+	}
+	dst["a"] = "modified"
+	if src["a"] != "1" {
+		t.Error("clone should be independent of source")
+	}
+}
+
+func TestLoadExistingEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+
+	if got, err := loadExistingEntry(path, "missing"); err != nil || got != nil {
+		t.Errorf("non-existent config: got=%v err=%v", got, err)
+	}
+
+	if err := os.WriteFile(path, []byte(`version: "1.0"
+servers:
+  - name: github
+    transport: stdio
+    enabled: true
+    stdio:
+      command: gh
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadExistingEntry(path, "github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Name != "github" {
+		t.Errorf("got = %+v, want github", got)
+	}
+	got, err = loadExistingEntry(path, "absent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("absent server returned %+v", got)
+	}
+}
+
+func TestDescriptionFor(t *testing.T) {
+	if got := descriptionFor(migrate.CacheEntry{URL: "https://x"}); got != "https://x" {
+		t.Errorf("URL precedence: got %q", got)
+	}
+	if got := descriptionFor(migrate.CacheEntry{Args: []string{"a", "b"}}); got != "a b" {
+		t.Errorf("Args: got %q", got)
+	}
+	if got := descriptionFor(migrate.CacheEntry{Command: "gh-mcp"}); got != "gh-mcp" {
+		t.Errorf("Command: got %q", got)
+	}
+	if got := descriptionFor(migrate.CacheEntry{}); got != "" {
+		t.Errorf("empty: got %q", got)
+	}
+}
+
+func TestRunAdd_EmptyArg(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runAdd(cmd, []string{""}); err == nil {
+		t.Fatal("expected error for empty arg")
+	}
+}
+
+func TestRunAdd_NoCacheReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "cfg")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LEANPROXY_CONFIG", filepath.Join(cfgDir, "leanproxy_servers.yaml"))
+	t.Setenv("HOME", dir)
+	// No .leanproxy directory exists -> empty cache.
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := runAdd(cmd, []string{"github"})
+	if err == nil {
+		t.Fatal("expected error when cache is empty")
+	}
+	if !strings.Contains(err.Error(), "marketplace sync") {
+		t.Errorf("error = %v, expected hint about marketplace sync", err)
+	}
+}
+
+func TestRunAdd_UnknownServerWithSuggestion(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "cfg")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LEANPROXY_CONFIG", filepath.Join(cfgDir, "leanproxy_servers.yaml"))
+	t.Setenv("HOME", dir)
+
+	// FeedFetcher caches under $HOME/.leanproxy/registry/.
+	writeIndex(t, filepath.Join(dir, ".leanproxy"), registry.FeedIndex{
+		SyncedAt: testNow(t),
+		Entries: []registry.RegistryFeedEntry{
+			{Name: "github", Transport: "stdio", Command: "gh"},
+		},
+	})
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+
+	err := runAdd(cmd, []string{"gitub"})
+	if err == nil {
+		t.Fatal("expected error for unknown server")
+	}
+	if !strings.Contains(err.Error(), "unknown server") {
+		t.Errorf("error = %v, expected 'unknown server' mention", err)
+	}
+	if !strings.Contains(stderr.String(), "leanproxy add github") {
+		t.Errorf("stderr should suggest 'leanproxy add github', got %q", stderr.String())
+	}
+}
+
+func TestRunAdd_FreshInstallWritesConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "cfg")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, "leanproxy_servers.yaml")
+	t.Setenv("LEANPROXY_CONFIG", cfgPath)
+	t.Setenv("HOME", dir)
+
+	writeIndex(t, filepath.Join(dir, ".leanproxy"), registry.FeedIndex{
+		SyncedAt: testNow(t),
+		Entries: []registry.RegistryFeedEntry{
+			{
+				Name:      "github",
+				Transport: "stdio",
+				Command:   "gh-mcp",
+				Args:      []string{"--stdio"},
+			},
+		},
+	})
+
+	stdout := &bytes.Buffer{}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := runAdd(cmd, []string{"github"}); err != nil {
+		t.Fatalf("runAdd: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	if !strings.Contains(string(data), "github") {
+		t.Errorf("config missing github: %s", data)
+	}
+	if !strings.Contains(stdout.String(), "Installed") {
+		t.Errorf("stdout should report install, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Token-cost preview") {
+		t.Errorf("stdout should include token-cost preview, got %q", stdout.String())
+	}
+}
+
+func testNow(_ *testing.T) time.Time {
+	return time.Now()
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/bouncer/snapshot.go
+++ b/pkg/bouncer/snapshot.go
@@ -1,0 +1,133 @@
+package bouncer
+
+import (
+	"fmt"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/utils"
+)
+
+const (
+	// DefaultEstimatedTools is the default tool-count estimate when the
+	// registry entry does not declare one. It matches the average used by
+	// pkg/utils.TokenEstimator.CompareMCPConfigurations.
+	DefaultEstimatedTools = 35
+
+	// estimatedToolsPerKB is a coarse heuristic used to derive a tool count
+	// from the registry entry's description when nothing else is available.
+	estimatedToolsPerKB = 40
+)
+
+// Snapshot describes the token impact of adding a server to a LeanProxy
+// deployment. It is computed from a registry feed entry before the server is
+// installed so the user can preview the cost.
+type Snapshot struct {
+	ServerName         string
+	Transport          string
+	EstimatedTools     int
+	NativeTokens       int
+	LeanProxyTokens    int
+	SavedTokens        int
+	SavingsPercent     float64
+	HasRegistryBudget  bool
+	RegistryBudgetNote string
+}
+
+// ComputeSnapshot returns a token-cost preview for the given server definition.
+//
+// The estimate is derived from the entry's declared tool count when available
+// (TokensPerTurn is treated as a per-turn override), otherwise from a default
+// heuristic. The LeanProxy cost assumes a single gateway schema (invoke_tool +
+// list_tools) regardless of how many real tools the server exposes.
+//
+// The returned Snapshot is safe for direct fmt.Stringer-style printing via
+// FormatSnapshot.
+func ComputeSnapshot(name, transport string, estimatedTools int, tokensPerTurn int64) Snapshot {
+	if name == "" {
+		name = "unknown"
+	}
+	if transport == "" {
+		transport = "stdio"
+	}
+	if estimatedTools <= 0 {
+		estimatedTools = DefaultEstimatedTools
+	}
+
+	estimator := utils.NewTokenEstimator()
+	native := estimator.EstimateNativeMCPOverhead(name, estimatedTools)
+	lean := estimator.EstimateLeanProxySchemaTokens()
+
+	saved := native - lean
+	if saved < 0 {
+		saved = 0
+	}
+	var pct float64
+	if native > 0 {
+		pct = float64(saved) / float64(native) * 100
+	}
+
+	return Snapshot{
+		ServerName:         name,
+		Transport:          transport,
+		EstimatedTools:     estimatedTools,
+		NativeTokens:       native,
+		LeanProxyTokens:    lean,
+		SavedTokens:        saved,
+		SavingsPercent:     pct,
+		HasRegistryBudget:  tokensPerTurn > 0,
+		RegistryBudgetNote: formatBudgetNote(tokensPerTurn),
+	}
+}
+
+// EstimateToolsFromDescription derives a coarse tool-count estimate from the
+// size of the registry entry's description. It is intentionally simple so it
+// can be used as a fallback when no other signal is present; callers should
+// prefer ComputeSnapshot with an explicit tool count whenever possible.
+func EstimateToolsFromDescription(description string) int {
+	if len(description) == 0 {
+		return DefaultEstimatedTools
+	}
+	kb := len(description) / 1024
+	if kb == 0 {
+		return DefaultEstimatedTools
+	}
+	estimate := kb * estimatedToolsPerKB
+	if estimate < DefaultEstimatedTools {
+		return DefaultEstimatedTools
+	}
+	return estimate
+}
+
+// FormatSnapshot renders the snapshot as a short human-readable block ready to
+// print to stdout. Lines are kept short for terminal readability.
+func FormatSnapshot(s Snapshot) string {
+	if s.SavedTokens <= 0 {
+		return fmt.Sprintf(
+			"Token-cost preview for %s (%s): ~%d native tokens / %d lean tokens (no savings)",
+			s.ServerName, s.Transport, s.NativeTokens, s.LeanProxyTokens,
+		)
+	}
+	return fmt.Sprintf(
+		"Token-cost preview for %s (%s, ~%d tools): ~%d native tokens vs. %d lean tokens (saves ~%d tokens / %s%%)",
+		s.ServerName, s.Transport, s.EstimatedTools,
+		s.NativeTokens, s.LeanProxyTokens, s.SavedTokens, formatPercent(s.SavingsPercent),
+	)
+}
+
+func formatPercent(p float64) string {
+	if p <= 0 {
+		return "0"
+	}
+	// One decimal place without trailing zeros.
+	whole := int(p)
+	if p-float64(whole) < 0.05 {
+		return fmt.Sprintf("%d", whole)
+	}
+	return fmt.Sprintf("%.1f", p)
+}
+
+func formatBudgetNote(tokensPerTurn int64) string {
+	if tokensPerTurn <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("Registry reports ~%d tokens/turn baseline.", tokensPerTurn)
+}

--- a/pkg/bouncer/snapshot_test.go
+++ b/pkg/bouncer/snapshot_test.go
@@ -1,0 +1,111 @@
+package bouncer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeSnapshot_DefaultsApplied(t *testing.T) {
+	s := ComputeSnapshot("", "", 0, 0)
+	if s.ServerName != "unknown" {
+		t.Errorf("ServerName = %q, want %q", s.ServerName, "unknown")
+	}
+	if s.Transport != "stdio" {
+		t.Errorf("Transport = %q, want %q", s.Transport, "stdio")
+	}
+	if s.EstimatedTools != DefaultEstimatedTools {
+		t.Errorf("EstimatedTools = %d, want %d", s.EstimatedTools, DefaultEstimatedTools)
+	}
+	if s.NativeTokens != DefaultEstimatedTools*75 {
+		t.Errorf("NativeTokens = %d, want %d", s.NativeTokens, DefaultEstimatedTools*75)
+	}
+	if !s.HasRegistryBudget && s.RegistryBudgetNote != "" {
+		t.Errorf("HasRegistryBudget false but budget note = %q", s.RegistryBudgetNote)
+	}
+}
+
+func TestComputeSnapshot_BasicMath(t *testing.T) {
+	s := ComputeSnapshot("github", "stdio", 20, 0)
+	if s.EstimatedTools != 20 {
+		t.Errorf("EstimatedTools = %d, want 20", s.EstimatedTools)
+	}
+	if s.NativeTokens != 1500 {
+		t.Errorf("NativeTokens = %d, want 1500", s.NativeTokens)
+	}
+	if s.LeanProxyTokens <= 0 {
+		t.Errorf("LeanProxyTokens should be positive, got %d", s.LeanProxyTokens)
+	}
+	if s.SavedTokens <= 0 {
+		t.Errorf("SavedTokens should be positive, got %d", s.SavedTokens)
+	}
+	if s.SavingsPercent <= 0 || s.SavingsPercent >= 100 {
+		t.Errorf("SavingsPercent out of range, got %v", s.SavingsPercent)
+	}
+}
+
+func TestComputeSnapshot_RegistryBudgetReported(t *testing.T) {
+	s := ComputeSnapshot("github", "stdio", 10, 1500)
+	if !s.HasRegistryBudget {
+		t.Error("HasRegistryBudget should be true when tokensPerTurn > 0")
+	}
+	if !strings.Contains(s.RegistryBudgetNote, "1500") {
+		t.Errorf("RegistryBudgetNote = %q, expected it to mention 1500", s.RegistryBudgetNote)
+	}
+}
+
+func TestComputeSnapshot_NegativeToolsDefaultsUp(t *testing.T) {
+	s := ComputeSnapshot("foo", "http", -5, 0)
+	if s.EstimatedTools != DefaultEstimatedTools {
+		t.Errorf("negative tool count should default, got %d", s.EstimatedTools)
+	}
+}
+
+func TestEstimateToolsFromDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want int
+	}{
+		{"empty uses default", "", DefaultEstimatedTools},
+		{"short uses default", "tiny description", DefaultEstimatedTools},
+		{"medium scales up", strings.Repeat("a", 5*1024), 5 * estimatedToolsPerKB},
+		{"floor enforced when below default", strings.Repeat("a", 512), DefaultEstimatedTools},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EstimateToolsFromDescription(tc.desc)
+			if got != tc.want {
+				t.Errorf("EstimateToolsFromDescription(len=%d) = %d, want %d", len(tc.desc), got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatSnapshot_ZeroSavings(t *testing.T) {
+	s := Snapshot{ServerName: "x", Transport: "stdio", EstimatedTools: 1, NativeTokens: 100, LeanProxyTokens: 100}
+	out := FormatSnapshot(s)
+	if !strings.Contains(out, "no savings") {
+		t.Errorf("FormatSnapshot with zero savings should mention 'no savings', got %q", out)
+	}
+	if !strings.Contains(out, "x") {
+		t.Errorf("FormatSnapshot should include server name, got %q", out)
+	}
+}
+
+func TestFormatSnapshot_PositiveSavings(t *testing.T) {
+	s := Snapshot{
+		ServerName:      "github",
+		Transport:       "stdio",
+		EstimatedTools:  20,
+		NativeTokens:    1500,
+		LeanProxyTokens: 200,
+		SavedTokens:     1300,
+		SavingsPercent:  86.6,
+	}
+	out := FormatSnapshot(s)
+	for _, frag := range []string{"github", "stdio", "20", "1500", "200", "1300"} {
+		if !strings.Contains(out, frag) {
+			t.Errorf("FormatSnapshot = %q, missing %q", out, frag)
+		}
+	}
+}

--- a/pkg/migrate/config.go
+++ b/pkg/migrate/config.go
@@ -55,18 +55,18 @@ type AuthConfig struct {
 }
 
 type ServerConfig struct {
-	Name                string         `yaml:"name"`
-	Enabled             *bool          `yaml:"enabled"`
-	Transport           TransportType  `yaml:"transport"`
-	Stdio               *StdioConfig   `yaml:"stdio,omitempty"`
-	HTTP                *HTTPConfig    `yaml:"http,omitempty"`
-	Timeout             string         `yaml:"timeout"`
-	TimeoutValue        time.Duration  `yaml:"-"`
-	ConnectTimeout      string         `yaml:"connect_timeout"`
-	ConnectTimeoutValue time.Duration  `yaml:"-"`
-	IdleTimeout         string         `yaml:"idle_timeout"`
-	IdleTimeoutValue    time.Duration  `yaml:"-"`
-	CacheSettings       *CacheSettings `yaml:"cache_settings,omitempty"`
+	Name                string             `yaml:"name"`
+	Enabled             *bool              `yaml:"enabled"`
+	Transport           TransportType      `yaml:"transport"`
+	Stdio               *StdioConfig       `yaml:"stdio,omitempty"`
+	HTTP                *HTTPConfig        `yaml:"http,omitempty"`
+	Timeout             string             `yaml:"timeout"`
+	TimeoutValue        time.Duration      `yaml:"-"`
+	ConnectTimeout      string             `yaml:"connect_timeout"`
+	ConnectTimeoutValue time.Duration      `yaml:"-"`
+	IdleTimeout         string             `yaml:"idle_timeout"`
+	IdleTimeoutValue    time.Duration      `yaml:"-"`
+	CacheSettings       *CacheSettings     `yaml:"cache_settings,omitempty"`
 	SummarizeSettings   *SummarizeSettings `yaml:"summarize_settings,omitempty"`
 }
 

--- a/pkg/migrate/config.go
+++ b/pkg/migrate/config.go
@@ -9,7 +9,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/mmornati/leanproxy-mcp/pkg/registry"
 	"github.com/mmornati/leanproxy-mcp/pkg/utils"
 )
 
@@ -56,19 +55,19 @@ type AuthConfig struct {
 }
 
 type ServerConfig struct {
-	Name                string                 `yaml:"name"`
-	Enabled             *bool                  `yaml:"enabled"`
-	Transport           registry.TransportType `yaml:"transport"`
-	Stdio               *StdioConfig           `yaml:"stdio,omitempty"`
-	HTTP                *HTTPConfig            `yaml:"http,omitempty"`
-	Timeout             string                 `yaml:"timeout"`
-	TimeoutValue        time.Duration          `yaml:"-"`
-	ConnectTimeout      string                 `yaml:"connect_timeout"`
-	ConnectTimeoutValue time.Duration          `yaml:"-"`
-	IdleTimeout         string                 `yaml:"idle_timeout"`
-	IdleTimeoutValue    time.Duration          `yaml:"-"`
-	CacheSettings       *CacheSettings         `yaml:"cache_settings,omitempty"`
-	SummarizeSettings   *SummarizeSettings     `yaml:"summarize_settings,omitempty"`
+	Name                string         `yaml:"name"`
+	Enabled             *bool          `yaml:"enabled"`
+	Transport           TransportType  `yaml:"transport"`
+	Stdio               *StdioConfig   `yaml:"stdio,omitempty"`
+	HTTP                *HTTPConfig    `yaml:"http,omitempty"`
+	Timeout             string         `yaml:"timeout"`
+	TimeoutValue        time.Duration  `yaml:"-"`
+	ConnectTimeout      string         `yaml:"connect_timeout"`
+	ConnectTimeoutValue time.Duration  `yaml:"-"`
+	IdleTimeout         string         `yaml:"idle_timeout"`
+	IdleTimeoutValue    time.Duration  `yaml:"-"`
+	CacheSettings       *CacheSettings `yaml:"cache_settings,omitempty"`
+	SummarizeSettings   *SummarizeSettings `yaml:"summarize_settings,omitempty"`
 }
 
 type Config struct {
@@ -101,11 +100,11 @@ func (c *ServerConfig) Validate() error {
 		return fmt.Errorf("server %s: transport type is required", c.Name)
 	}
 	switch c.Transport {
-	case registry.TransportStdio:
+	case TransportStdio:
 		if c.Stdio == nil || c.Stdio.Command == "" {
 			return fmt.Errorf("server %s: command is required for stdio transport", c.Name)
 		}
-	case registry.TransportHTTP, registry.TransportSSE:
+	case TransportHTTP, TransportSSE:
 		if c.HTTP == nil || c.HTTP.URL == "" {
 			return fmt.Errorf("server %s: url is required for %s transport", c.Name, c.Transport)
 		}

--- a/pkg/migrate/config_test.go
+++ b/pkg/migrate/config_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/mmornati/leanproxy-mcp/pkg/registry"
 )
 
 func TestLoadConfigMinimal(t *testing.T) {
@@ -39,7 +37,7 @@ servers:
 	if server.Name != "test-server" {
 		t.Errorf("Name = %v, want test-server", server.Name)
 	}
-	if server.Transport != registry.TransportStdio {
+	if server.Transport != TransportStdio {
 		t.Errorf("Transport = %v, want stdio", server.Transport)
 	}
 	if server.Enabled == nil || !*server.Enabled {
@@ -100,7 +98,7 @@ servers:
 	if server.Enabled != nil && *server.Enabled {
 		t.Error("Enabled should be false")
 	}
-	if server.Transport != registry.TransportHTTP {
+	if server.Transport != TransportHTTP {
 		t.Errorf("Transport = %v, want http", server.Transport)
 	}
 	if server.HTTP.URL != "http://localhost:8080" {
@@ -218,7 +216,7 @@ func TestServerConfigValidate(t *testing.T) {
 			name: "valid stdio server",
 			server: &ServerConfig{
 				Name:      "test",
-				Transport: registry.TransportStdio,
+				Transport: TransportStdio,
 				Stdio:     &StdioConfig{Command: "/bin/server"},
 			},
 			wantErr: false,
@@ -227,7 +225,7 @@ func TestServerConfigValidate(t *testing.T) {
 			name: "valid http server",
 			server: &ServerConfig{
 				Name:      "test-http",
-				Transport: registry.TransportHTTP,
+				Transport: TransportHTTP,
 				HTTP:      &HTTPConfig{URL: "http://localhost:8080"},
 			},
 			wantErr: false,
@@ -236,14 +234,14 @@ func TestServerConfigValidate(t *testing.T) {
 			name: "valid sse server",
 			server: &ServerConfig{
 				Name:      "test-sse",
-				Transport: registry.TransportSSE,
+				Transport: TransportSSE,
 				HTTP:      &HTTPConfig{URL: "http://localhost:8080/sse"},
 			},
 			wantErr: false,
 		},
 		{
 			name:    "missing name",
-			server:  &ServerConfig{Transport: registry.TransportStdio, Stdio: &StdioConfig{Command: "/bin/server"}},
+			server:  &ServerConfig{Transport: TransportStdio, Stdio: &StdioConfig{Command: "/bin/server"}},
 			wantErr: true,
 			errMsg:  "server name is required",
 		},
@@ -257,7 +255,7 @@ func TestServerConfigValidate(t *testing.T) {
 			name: "stdio missing command",
 			server: &ServerConfig{
 				Name:      "test",
-				Transport: registry.TransportStdio,
+				Transport: TransportStdio,
 				Stdio:     &StdioConfig{},
 			},
 			wantErr: true,
@@ -267,7 +265,7 @@ func TestServerConfigValidate(t *testing.T) {
 			name: "http missing url",
 			server: &ServerConfig{
 				Name:      "test",
-				Transport: registry.TransportHTTP,
+				Transport: TransportHTTP,
 				HTTP:      &HTTPConfig{},
 			},
 			wantErr: true,
@@ -277,7 +275,7 @@ func TestServerConfigValidate(t *testing.T) {
 			name: "sse missing url",
 			server: &ServerConfig{
 				Name:      "test",
-				Transport: registry.TransportSSE,
+				Transport: TransportSSE,
 				HTTP:      &HTTPConfig{},
 			},
 			wantErr: true,
@@ -323,8 +321,8 @@ func containsHelper(s, substr string) bool {
 func TestConfigValidate(t *testing.T) {
 	cfg := &Config{
 		Servers: []*ServerConfig{
-			{Name: "valid", Transport: registry.TransportStdio, Stdio: &StdioConfig{Command: "/bin/server"}},
-			{Name: "invalid-stdio", Transport: registry.TransportStdio, Stdio: &StdioConfig{}},
+			{Name: "valid", Transport: TransportStdio, Stdio: &StdioConfig{Command: "/bin/server"}},
+			{Name: "invalid-stdio", Transport: TransportStdio, Stdio: &StdioConfig{}},
 		},
 	}
 	err := cfg.Validate()
@@ -352,7 +350,7 @@ servers:
 	if err != nil {
 		t.Fatalf("LoadConfig() failed: %v", err)
 	}
-	if cfg.Servers[0].Transport != registry.TransportSSE {
+	if cfg.Servers[0].Transport != TransportSSE {
 		t.Errorf("Transport = %v, want sse", cfg.Servers[0].Transport)
 	}
 }

--- a/pkg/migrate/installer.go
+++ b/pkg/migrate/installer.go
@@ -1,0 +1,527 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// SimilarityLimit bounds the number of "did you mean" suggestions returned by
+// Install when the requested server id is not in the registry cache.
+const SimilarityLimit = 5
+
+// ServerSource is the minimal interface the installer needs from a registry
+// cache. It is satisfied by *registry.FeedFetcher (which returns a
+// *registry.FeedIndex) but defined here to avoid an import cycle with the
+// registry package, which in turn depends on this package for the ServerConfig
+// schema.
+type ServerSource interface {
+	// LookupCache returns the list of (name, transport, command, url,
+	// tokens-per-turn) records available locally. The bool reports whether
+	// any cache was present; an empty slice with bool == true means "cache
+	// exists but is empty".
+	LookupCache(ctx context.Context) (CacheSnapshot, error)
+}
+
+// CacheEntry is the subset of a registry feed record the installer cares
+// about. Defining it here keeps the installer decoupled from the registry
+// package's concrete types.
+type CacheEntry struct {
+	Name          string
+	Transport     string
+	Command       string
+	Args          []string
+	Env           map[string]string
+	URL           string
+	TokensPerTurn int64
+}
+
+// CacheSnapshot is the materialised view of the registry cache. It is
+// returned by ServerSource.LookupCache.
+type CacheSnapshot struct {
+	Entries []CacheEntry
+}
+
+// ErrUnknownServer is returned by Install when the requested server id is not
+// present in the local registry cache. It carries suggested similar names so
+// callers can present a "did you mean" hint without re-running the search.
+type ErrUnknownServer struct {
+	ServerID  string
+	Suggested []string
+}
+
+func (e *ErrUnknownServer) Error() string {
+	if len(e.Suggested) == 0 {
+		return fmt.Sprintf("unknown server: %q", e.ServerID)
+	}
+	return fmt.Sprintf("unknown server: %q (did you mean: %s)", e.ServerID, strings.Join(e.Suggested, ", "))
+}
+
+// IsUnknownServer reports whether err (or any wrapped error) is an
+// ErrUnknownServer.
+func IsUnknownServer(err error) bool {
+	var target *ErrUnknownServer
+	return errors.As(err, &target)
+}
+
+// ErrAlreadyInstalled is returned when the server name already exists in the
+// user config and neither Force nor an interactive confirmation has been
+// supplied.
+type ErrAlreadyInstalled struct {
+	ServerID string
+}
+
+func (e *ErrAlreadyInstalled) Error() string {
+	return fmt.Sprintf("server already installed: %q (use --force to replace)", e.ServerID)
+}
+
+// IsAlreadyInstalled reports whether err (or any wrapped error) is an
+// ErrAlreadyInstalled.
+func IsAlreadyInstalled(err error) bool {
+	var target *ErrAlreadyInstalled
+	return errors.As(err, &target)
+}
+
+// LifecycleStopper is the narrow surface the installer needs from a server
+// lifecycle manager. The concrete *registry.LifecycleManager satisfies it via
+// its Stop method, but the installer accepts the interface so callers can
+// pass a fake in tests.
+type LifecycleStopper interface {
+	Stop(ctx context.Context, id string) error
+}
+
+// InstallOptions controls Install behaviour. The zero value performs an
+// additive install with no graceful stop and no lifecycle manager.
+type InstallOptions struct {
+	// Force, when true, allows overwriting an existing server definition.
+	Force bool
+
+	// StopExisting, when true, asks the stopper to gracefully stop any
+	// running instance that shares the target name before the new definition
+	// is written.
+	StopExisting bool
+
+	// GracefulTimeout is the budget for the graceful stop before the caller
+	// proceeds with the install regardless. Zero means use the stop call's
+	// default context.
+	GracefulTimeout time.Duration
+
+	// Stopper, when set, is invoked to stop existing instances when
+	// StopExisting is true. It may be nil for offline (config-only) installs.
+	Stopper LifecycleStopper
+
+	// Logger is used for operational logs. Defaults to slog.Default().
+	Logger *slog.Logger
+
+	// DryRun, when true, prevents any filesystem writes and any stopper
+	// calls. The result still reflects what would have happened.
+	DryRun bool
+}
+
+// InstallResult captures the outcome of a successful Install call. It is
+// always non-nil when err is nil.
+type InstallResult struct {
+	ServerID        string
+	ServerName      string
+	Transport       string
+	Replaced        bool
+	Stopped         bool
+	ConfigPath      string
+	DryRun          bool
+	EstimatedTools  int
+	SnapshotSummary string
+}
+
+// Installer is the top-level facade used by cmd/add. It composes a cache
+// source and a config path.
+type Installer struct {
+	Source     ServerSource
+	ConfigPath string
+	Logger     *slog.Logger
+}
+
+// NewInstaller wires an Installer with the given cache source and config
+// path. Either may be overridden after construction by setting the fields
+// directly.
+func NewInstaller(source ServerSource, configPath string, logger *slog.Logger) *Installer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Installer{Source: source, ConfigPath: configPath, Logger: logger}
+}
+
+// Resolve returns the registry entry for serverID (case-insensitive). If no
+// exact match is found, it returns an *ErrUnknownServer populated with up to
+// SimilarityLimit suggestions ranked by edit distance.
+//
+// Resolve never triggers a Sync; callers are expected to have a fresh cache.
+func (i *Installer) Resolve(ctx context.Context, serverID string) (CacheEntry, error) {
+	if serverID == "" {
+		return CacheEntry{}, &ErrUnknownServer{ServerID: serverID}
+	}
+
+	snap, err := i.Source.LookupCache(ctx)
+	if err != nil {
+		return CacheEntry{}, fmt.Errorf("installer: load cache: %w", err)
+	}
+
+	want := strings.ToLower(serverID)
+	for _, e := range snap.Entries {
+		if strings.ToLower(e.Name) == want {
+			return e, nil
+		}
+	}
+
+	suggested := SuggestSimilar(serverID, snap.Entries, SimilarityLimit)
+	return CacheEntry{}, &ErrUnknownServer{ServerID: serverID, Suggested: suggested}
+}
+
+// Install builds a ServerConfig from the cache entry, merges it into the user
+// config at i.ConfigPath (writing through MarshalConfig), and — if
+// StopExisting is true — gracefully stops any running instance that shares the
+// target name via the provided Stopper.
+//
+// The returned result is always non-nil when err is nil.
+func (i *Installer) Install(ctx context.Context, entry CacheEntry, opts InstallOptions) (*InstallResult, error) {
+	if entry.Name == "" {
+		return nil, fmt.Errorf("installer: cache entry has empty Name")
+	}
+
+	logger := opts.Logger
+	if logger == nil {
+		logger = i.Logger
+	}
+
+	sc, err := buildServerConfig(entry)
+	if err != nil {
+		return nil, fmt.Errorf("installer: build config for %q: %w", entry.Name, err)
+	}
+
+	path := i.ConfigPath
+	if path == "" {
+		path = defaultUserConfigPath()
+	}
+
+	cfg, err := LoadConfig(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("installer: load config %s: %w", path, err)
+	}
+	if cfg == nil {
+		cfg = &Config{Version: "1.0", Servers: []*ServerConfig{}}
+	}
+
+	result := &InstallResult{
+		ServerID:   sc.Name,
+		ServerName: sc.Name,
+		ConfigPath: path,
+	}
+
+	existingIdx := findServerIndex(cfg.Servers, sc.Name)
+	replaced := existingIdx >= 0
+	if replaced && !opts.Force {
+		return nil, &ErrAlreadyInstalled{ServerID: sc.Name}
+	}
+	result.Replaced = replaced
+	result.Transport = string(sc.Transport)
+
+	if opts.StopExisting && replaced && opts.Stopper != nil {
+		if !opts.DryRun {
+			stopCtx := ctx
+			if opts.GracefulTimeout > 0 {
+				var cancel context.CancelFunc
+				stopCtx, cancel = context.WithTimeout(ctx, opts.GracefulTimeout)
+				defer cancel()
+			}
+			if err := opts.Stopper.Stop(stopCtx, sc.Name); err != nil {
+				logger.Warn("installer: graceful stop failed; continuing with install",
+					"server", sc.Name, "error", err)
+			} else {
+				result.Stopped = true
+			}
+		} else {
+			result.Stopped = true
+		}
+	}
+
+	if replaced {
+		cfg.Servers[existingIdx] = sc
+	} else {
+		cfg.Servers = append(cfg.Servers, sc)
+	}
+
+	if opts.DryRun {
+		result.DryRun = true
+		return result, nil
+	}
+
+	if err := SaveConfig(path, cfg); err != nil {
+		return nil, fmt.Errorf("installer: save config: %w", err)
+	}
+
+	logger.Info("server installed from registry",
+		"server", sc.Name,
+		"transport", sc.Transport,
+		"replaced", result.Replaced,
+		"stopped", result.Stopped,
+		"path", path)
+
+	return result, nil
+}
+
+// SaveConfig writes cfg to path with 0600 permissions, creating the parent
+// directory if needed. The write is atomic: a temp file in the same
+// directory is created, fsynced, then renamed over the target.
+func SaveConfig(path string, cfg *Config) error {
+	if path == "" {
+		return fmt.Errorf("installer: empty config path")
+	}
+	data, err := MarshalConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("installer: marshal config: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("installer: create config dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".leanproxy-*.yaml.tmp") // #nosec G304 -- path provided by caller via opts
+	if err != nil {
+		return fmt.Errorf("installer: create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("installer: write temp file: %w", err)
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		cleanup()
+		return fmt.Errorf("installer: chmod temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("installer: sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("installer: close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("installer: rename temp file: %w", err)
+	}
+	return nil
+}
+
+// defaultUserConfigPath returns the standard user config path used when no
+// override is supplied via the Installer. It mirrors userConfigPath in cmd/.
+func defaultUserConfigPath() string {
+	if p := os.Getenv("LEANPROXY_CONFIG"); p != "" {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return filepath.Join(".config", "leanproxy_servers.yaml")
+	}
+	return filepath.Join(home, ".config", "leanproxy_servers.yaml")
+}
+
+// buildServerConfig converts a CacheEntry into a ServerConfig that the rest of
+// the system can persist, validate, and start. Stdio is preferred when a
+// Command is present; otherwise HTTP is used and the URL is promoted into
+// http.url.
+func buildServerConfig(entry CacheEntry) (*ServerConfig, error) {
+	transport, err := normaliseTransport(entry.Transport)
+	if err != nil {
+		return nil, err
+	}
+
+	enabled := true
+	sc := &ServerConfig{
+		Name:           entry.Name,
+		Enabled:        &enabled,
+		Transport:      transport,
+		Timeout:        "30s",
+		ConnectTimeout: "10s",
+	}
+
+	switch transport {
+	case TransportStdio:
+		if entry.Command == "" {
+			return nil, fmt.Errorf("registry entry %q has no Command for stdio transport", entry.Name)
+		}
+		sc.Stdio = &StdioConfig{
+			Command: entry.Command,
+			Args:    append([]string(nil), entry.Args...),
+			Env:     flattenEnv(entry.Env),
+		}
+	case TransportHTTP, TransportSSE:
+		if entry.URL == "" {
+			return nil, fmt.Errorf("registry entry %q has no URL for %s transport", entry.Name, transport)
+		}
+		sc.HTTP = &HTTPConfig{
+			URL:     entry.URL,
+			Headers: cloneHeaders(entry.Env),
+		}
+	default:
+		return nil, fmt.Errorf("registry entry %q has unsupported transport %q", entry.Name, transport)
+	}
+
+	return sc, nil
+}
+
+func normaliseTransport(raw string) (TransportType, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "stdio":
+		return TransportStdio, nil
+	case "http", "streamable-http", "streamable_http":
+		return TransportHTTP, nil
+	case "sse":
+		return TransportSSE, nil
+	default:
+		return "", fmt.Errorf("unsupported transport %q", raw)
+	}
+}
+
+func flattenEnv(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(env))
+	for _, k := range keys {
+		out = append(out, fmt.Sprintf("%s=%s", k, env[k]))
+	}
+	return out
+}
+
+// cloneHeaders duplicates env as HTTP headers, picking keys prefixed with
+// header_ (case-insensitive) and stripping the prefix. Returns nil when no
+// header_* keys are present to avoid emitting an empty `headers: {}` block in
+// YAML.
+func cloneHeaders(env map[string]string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(env))
+	for k, v := range env {
+		lower := strings.ToLower(k)
+		if strings.HasPrefix(lower, "header_") {
+			out[strings.TrimPrefix(lower, "header_")] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func findServerIndex(servers []*ServerConfig, name string) int {
+	for i, s := range servers {
+		if s == nil {
+			continue
+		}
+		if s.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// SuggestSimilar ranks entries by Levenshtein distance to needle and returns
+// the top-n closest names. Identical matches are excluded (Resolve handles
+// the exact case before calling this helper).
+func SuggestSimilar(needle string, entries []CacheEntry, limit int) []string {
+	type scored struct {
+		name  string
+		score int
+	}
+	want := strings.ToLower(needle)
+	scoredEntries := make([]scored, 0, len(entries))
+	for _, e := range entries {
+		if e.Name == "" {
+			continue
+		}
+		low := strings.ToLower(e.Name)
+		if low == want {
+			continue
+		}
+		scoredEntries = append(scoredEntries, scored{
+			name:  e.Name,
+			score: levenshtein(want, low),
+		})
+	}
+	sort.SliceStable(scoredEntries, func(a, b int) bool {
+		return scoredEntries[a].score < scoredEntries[b].score
+	})
+	if limit > 0 && len(scoredEntries) > limit {
+		scoredEntries = scoredEntries[:limit]
+	}
+	out := make([]string, 0, len(scoredEntries))
+	for _, s := range scoredEntries {
+		out = append(out, s.name)
+	}
+	return out
+}
+
+// levenshtein computes the edit distance between a and b using the classic
+// dynamic-programming algorithm with O(min(|a|,|b|)) memory. Both inputs are
+// expected to be already lower-cased by the caller.
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	if len(a) < len(b) {
+		a, b = b, a
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for i := 0; i <= len(b); i++ {
+		prev[i] = i
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}

--- a/pkg/migrate/installer.go
+++ b/pkg/migrate/installer.go
@@ -42,7 +42,7 @@ type CacheEntry struct {
 	TokensPerTurn int64
 }
 
-// CacheSnapshot is the materialised view of the registry cache. It is
+// CacheSnapshot is the materialized view of the registry cache. It is
 // returned by ServerSource.LookupCache.
 type CacheSnapshot struct {
 	Entries []CacheEntry
@@ -96,7 +96,7 @@ type LifecycleStopper interface {
 	Stop(ctx context.Context, id string) error
 }
 
-// InstallOptions controls Install behaviour. The zero value performs an
+// InstallOptions controls Install behavior. The zero value performs an
 // additive install with no graceful stop and no lifecycle manager.
 type InstallOptions struct {
 	// Force, when true, allows overwriting an existing server definition.

--- a/pkg/migrate/installer_test.go
+++ b/pkg/migrate/installer_test.go
@@ -1,0 +1,461 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeSource is an in-memory ServerSource used by installer tests.
+type fakeSource struct {
+	entries []CacheEntry
+	err     error
+}
+
+func (f *fakeSource) LookupCache(_ context.Context) (CacheSnapshot, error) {
+	if f.err != nil {
+		return CacheSnapshot{}, f.err
+	}
+	return CacheSnapshot{Entries: f.entries}, nil
+}
+
+type fakeStopper struct {
+	stopped []string
+	err     error
+}
+
+func (f *fakeStopper) Stop(_ context.Context, id string) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.stopped = append(f.stopped, id)
+	return nil
+}
+
+func TestResolve_ExactMatch(t *testing.T) {
+	src := &fakeSource{entries: []CacheEntry{
+		{Name: "github", Transport: "stdio", Command: "gh-mcp"},
+		{Name: "filesystem", Transport: "stdio", Command: "fs-mcp"},
+	}}
+	inst := NewInstaller(src, "", nil)
+
+	got, err := inst.Resolve(context.Background(), "github")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if got.Name != "github" {
+		t.Errorf("Resolve = %q, want %q", got.Name, "github")
+	}
+}
+
+func TestResolve_CaseInsensitive(t *testing.T) {
+	src := &fakeSource{entries: []CacheEntry{{Name: "GitHub", Transport: "stdio", Command: "gh"}}}
+	inst := NewInstaller(src, "", nil)
+
+	got, err := inst.Resolve(context.Background(), "github")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if got.Name != "GitHub" {
+		t.Errorf("Resolve = %q, want %q (case preserved)", got.Name, "GitHub")
+	}
+}
+
+func TestResolve_UnknownWithSuggestions(t *testing.T) {
+	src := &fakeSource{entries: []CacheEntry{
+		{Name: "github", Transport: "stdio"},
+		{Name: "gitlab", Transport: "stdio"},
+		{Name: "bitbucket", Transport: "stdio"},
+		{Name: "files", Transport: "stdio"},
+	}}
+	inst := NewInstaller(src, "", nil)
+
+	_, err := inst.Resolve(context.Background(), "gitub")
+	if !IsUnknownServer(err) {
+		t.Fatalf("expected ErrUnknownServer, got %v", err)
+	}
+	var unk *ErrUnknownServer
+	if !errors.As(err, &unk) {
+		t.Fatalf("errors.As failed for %v", err)
+	}
+	if len(unk.Suggested) == 0 {
+		t.Fatal("expected at least one suggestion for close typo")
+	}
+	if unk.Suggested[0] != "github" {
+		t.Errorf("top suggestion = %q, want %q", unk.Suggested[0], "github")
+	}
+	if len(unk.Suggested) > SimilarityLimit {
+		t.Errorf("suggestions exceed limit: %d", len(unk.Suggested))
+	}
+}
+
+func TestResolve_UnknownEmptyID(t *testing.T) {
+	inst := NewInstaller(&fakeSource{}, "", nil)
+	_, err := inst.Resolve(context.Background(), "")
+	if !IsUnknownServer(err) {
+		t.Fatalf("expected ErrUnknownServer, got %v", err)
+	}
+}
+
+func TestResolve_SourceErrorWrapped(t *testing.T) {
+	src := &fakeSource{err: errors.New("disk on fire")}
+	inst := NewInstaller(src, "", nil)
+	_, err := inst.Resolve(context.Background(), "github")
+	if err == nil || IsUnknownServer(err) {
+		t.Fatalf("expected wrapped source error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "load cache") {
+		t.Errorf("error should mention load cache, got %v", err)
+	}
+}
+
+func TestInstall_FreshStdioInstall(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+
+	src := &fakeSource{entries: []CacheEntry{{
+		Name: "github", Transport: "stdio", Command: "gh-mcp",
+		Args: []string{"--port", "8080"},
+		Env:  map[string]string{"GITHUB_TOKEN": "secret"},
+	}}}
+	inst := NewInstaller(src, cfgPath, nil)
+
+	res, err := inst.Install(context.Background(), CacheEntry{
+		Name: "github", Transport: "stdio", Command: "gh-mcp",
+		Args: []string{"--port", "8080"},
+		Env:  map[string]string{"GITHUB_TOKEN": "secret"},
+	}, InstallOptions{})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if res.Replaced {
+		t.Error("Replaced should be false on fresh install")
+	}
+	if res.ServerName != "github" {
+		t.Errorf("ServerName = %q, want %q", res.ServerName, "github")
+	}
+	if res.ConfigPath != cfgPath {
+		t.Errorf("ConfigPath = %q, want %q", res.ConfigPath, cfgPath)
+	}
+
+	// Verify the config file was written.
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	if !strings.Contains(string(data), "github") {
+		t.Errorf("config missing server name: %s", data)
+	}
+	if !strings.Contains(string(data), "gh-mcp") {
+		t.Errorf("config missing command: %s", data)
+	}
+
+	info, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("config perm = %o, want 0600", perm)
+	}
+}
+
+func TestInstall_HTTPTransportUsesURL(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+
+	entry := CacheEntry{Name: "remote", Transport: "http", URL: "https://example.com/mcp"}
+	src := &fakeSource{entries: []CacheEntry{entry}}
+	inst := NewInstaller(src, cfgPath, nil)
+
+	res, err := inst.Install(context.Background(), entry, InstallOptions{})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if res.Transport != "http" {
+		t.Errorf("Transport = %q, want http", res.Transport)
+	}
+
+	cfg, err := LoadConfig(context.Background(), cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Servers) != 1 || cfg.Servers[0].HTTP == nil {
+		t.Fatalf("expected one HTTP server, got %+v", cfg.Servers)
+	}
+	if cfg.Servers[0].HTTP.URL != "https://example.com/mcp" {
+		t.Errorf("HTTP.URL = %q", cfg.Servers[0].HTTP.URL)
+	}
+}
+
+func TestInstall_StdioRequiresCommand(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	src := &fakeSource{}
+	inst := NewInstaller(src, cfgPath, nil)
+
+	_, err := inst.Install(context.Background(), CacheEntry{Name: "broken", Transport: "stdio"}, InstallOptions{})
+	if err == nil || !strings.Contains(err.Error(), "Command") {
+		t.Fatalf("expected command-required error, got %v", err)
+	}
+}
+
+func TestInstall_HTTPRequiresURL(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+
+	_, err := inst.Install(context.Background(), CacheEntry{Name: "broken", Transport: "http"}, InstallOptions{})
+	if err == nil || !strings.Contains(err.Error(), "URL") {
+		t.Fatalf("expected url-required error, got %v", err)
+	}
+}
+
+func TestInstall_UnsupportedTransport(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+
+	_, err := inst.Install(context.Background(), CacheEntry{Name: "x", Transport: "grpc"}, InstallOptions{})
+	if err == nil || !strings.Contains(err.Error(), "unsupported transport") {
+		t.Fatalf("expected unsupported transport error, got %v", err)
+	}
+}
+
+func TestInstall_RejectsExistingWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\nservers:\n  - name: github\n    transport: stdio\n    stdio:\n      command: old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+	_, err := inst.Install(context.Background(), CacheEntry{Name: "github", Transport: "stdio", Command: "new"}, InstallOptions{})
+	if !IsAlreadyInstalled(err) {
+		t.Fatalf("expected ErrAlreadyInstalled, got %v", err)
+	}
+}
+
+func TestInstall_ForceReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\nservers:\n  - name: github\n    transport: stdio\n    enabled: true\n    stdio:\n      command: old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+	res, err := inst.Install(context.Background(), CacheEntry{Name: "github", Transport: "stdio", Command: "new"}, InstallOptions{Force: true})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !res.Replaced {
+		t.Error("Replaced should be true")
+	}
+
+	cfg, err := LoadConfig(context.Background(), cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Servers) != 1 {
+		t.Fatalf("expected 1 server after replace, got %d", len(cfg.Servers))
+	}
+	if cfg.Servers[0].Stdio.Command != "new" {
+		t.Errorf("Command = %q, want %q", cfg.Servers[0].Stdio.Command, "new")
+	}
+}
+
+func TestInstall_StopExisting(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\nservers:\n  - name: github\n    transport: stdio\n    enabled: true\n    stdio:\n      command: old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stopper := &fakeStopper{}
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+	res, err := inst.Install(context.Background(), CacheEntry{Name: "github", Transport: "stdio", Command: "new"}, InstallOptions{
+		Force:           true,
+		StopExisting:    true,
+		GracefulTimeout: 50 * time.Millisecond,
+		Stopper:         stopper,
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !res.Stopped {
+		t.Error("Stopped should be true")
+	}
+	if len(stopper.stopped) != 1 || stopper.stopped[0] != "github" {
+		t.Errorf("stopper called with %v, want [github]", stopper.stopped)
+	}
+}
+
+func TestInstall_StopperErrorContinues(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\nservers:\n  - name: github\n    transport: stdio\n    enabled: true\n    stdio:\n      command: old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stopper := &fakeStopper{err: errors.New("boom")}
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+	res, err := inst.Install(context.Background(), CacheEntry{Name: "github", Transport: "stdio", Command: "new"}, InstallOptions{
+		Force:        true,
+		StopExisting: true,
+		Stopper:      stopper,
+	})
+	if err != nil {
+		t.Fatalf("Install should not fail when stopper fails: %v", err)
+	}
+	if res.Stopped {
+		t.Error("Stopped should be false when stopper errors")
+	}
+	// Config should still be updated.
+	cfg, err := LoadConfig(context.Background(), cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Servers) != 1 || cfg.Servers[0].Stdio.Command != "new" {
+		t.Errorf("config not updated: %+v", cfg.Servers)
+	}
+}
+
+func TestInstall_DryRunNoWrite(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+	res, err := inst.Install(context.Background(), CacheEntry{Name: "github", Transport: "stdio", Command: "gh"}, InstallOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !res.DryRun {
+		t.Error("DryRun should be true in result")
+	}
+	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
+		t.Errorf("config file should not exist on dry-run, got err=%v", err)
+	}
+}
+
+func TestInstall_DryRunStopsExisting(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	if err := os.WriteFile(cfgPath, []byte("version: \"1.0\"\nservers:\n  - name: github\n    transport: stdio\n    enabled: true\n    stdio:\n      command: old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stopper := &fakeStopper{}
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+	res, err := inst.Install(context.Background(), CacheEntry{Name: "github", Transport: "stdio", Command: "new"}, InstallOptions{
+		Force:        true,
+		StopExisting: true,
+		Stopper:      stopper,
+		DryRun:       true,
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !res.Stopped {
+		t.Error("DryRun should report Stopped=true")
+	}
+	if len(stopper.stopped) != 0 {
+		t.Errorf("stopper should not be called during dry-run, got %v", stopper.stopped)
+	}
+}
+
+func TestInstall_CreatesMissingConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "nested", "deep", "leanproxy_servers.yaml")
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+	_, err := inst.Install(context.Background(), CacheEntry{Name: "github", Transport: "stdio", Command: "gh"}, InstallOptions{})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Errorf("expected config to be created: %v", err)
+	}
+}
+
+func TestInstall_HeaderPrefixBecomesHTTPHeader(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "leanproxy_servers.yaml")
+	inst := NewInstaller(&fakeSource{}, cfgPath, nil)
+	entry := CacheEntry{
+		Name:      "remote",
+		Transport: "http",
+		URL:       "https://example.com",
+		Env: map[string]string{
+			"HEADER_AUTHORIZATION": "Bearer abc",
+			"GITHUB_TOKEN":         "secret",
+		},
+	}
+	_, err := inst.Install(context.Background(), entry, InstallOptions{})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	cfg, err := LoadConfig(context.Background(), cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Servers[0].HTTP.Headers["authorization"] != "Bearer abc" {
+		t.Errorf("expected authorization header, got %+v", cfg.Servers[0].HTTP.Headers)
+	}
+	if _, ok := cfg.Servers[0].HTTP.Headers["GITHUB_TOKEN"]; ok {
+		t.Error("non-header env should not be promoted to header")
+	}
+}
+
+func TestSuggestSimilar_LimitAndOrder(t *testing.T) {
+	entries := []CacheEntry{
+		{Name: "github"}, {Name: "gitlab"}, {Name: "bitbucket"},
+		{Name: "dropbox"}, {Name: "filesystem"}, {Name: "sentry"},
+	}
+	got := SuggestSimilar("githob", entries, 3)
+	if len(got) != 3 {
+		t.Fatalf("got %d suggestions, want 3", len(got))
+	}
+	if got[0] != "github" {
+		t.Errorf("top suggestion = %q, want github", got[0])
+	}
+}
+
+func TestSuggestSimilar_ExcludesExactMatch(t *testing.T) {
+	entries := []CacheEntry{{Name: "github"}, {Name: "gitlab"}}
+	got := SuggestSimilar("github", entries, 5)
+	for _, s := range got {
+		if s == "github" {
+			t.Error("exact match should not appear in suggestions")
+		}
+	}
+}
+
+func TestLevenshtein_KnownPairs(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"a", "", 1},
+		{"", "abc", 3},
+		{"abc", "abc", 0},
+		{"kitten", "sitting", 3},
+		{"flaw", "lawn", 2},
+		{"a", "b", 1},
+	}
+	for _, tc := range tests {
+		got := levenshtein(tc.a, tc.b)
+		if got != tc.want {
+			t.Errorf("levenshtein(%q,%q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestSaveConfig_EmptyPath(t *testing.T) {
+	if err := SaveConfig("", &Config{}); err == nil {
+		t.Error("expected error for empty path")
+	}
+}
+
+func TestNewInstaller_NilLogger(t *testing.T) {
+	inst := NewInstaller(&fakeSource{}, "/tmp/x.yaml", nil)
+	if inst.Logger == nil {
+		t.Error("NewInstaller should default Logger to slog.Default()")
+	}
+}

--- a/pkg/migrate/scanner.go
+++ b/pkg/migrate/scanner.go
@@ -6,14 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	"github.com/mmornati/leanproxy-mcp/pkg/registry"
 )
 
 type DiscoveredServer struct {
 	Name      string
 	Source    string
-	Transport registry.TransportType
+	Transport TransportType
 	Stdio     *StdioConfig
 	HTTP      *HTTPConfig
 	Enabled   *bool
@@ -54,14 +52,14 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-func validateTransport(transport string) (registry.TransportType, error) {
+func validateTransport(transport string) (TransportType, error) {
 	switch transport {
 	case "stdio":
-		return registry.TransportStdio, nil
+		return TransportStdio, nil
 	case "http":
-		return registry.TransportHTTP, nil
+		return TransportHTTP, nil
 	case "sse":
-		return registry.TransportSSE, nil
+		return TransportSSE, nil
 	default:
 		return "", fmt.Errorf("invalid transport type: %s", transport)
 	}

--- a/pkg/migrate/transport.go
+++ b/pkg/migrate/transport.go
@@ -1,0 +1,16 @@
+// Package migrate owns the on-disk YAML schema for LeanProxy's
+// user-server configuration. It re-exports the canonical transport enum used
+// throughout the codebase so callers can refer to it without depending on
+// pkg/registry (which already depends on this package for ServerConfig).
+package migrate
+
+// TransportType enumerates the wire transports a server may speak. The
+// string values are part of the public YAML schema and must not change
+// without a migration step.
+type TransportType string
+
+const (
+	TransportStdio TransportType = "stdio"
+	TransportHTTP  TransportType = "http"
+	TransportSSE   TransportType = "sse"
+)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -11,15 +11,16 @@ import (
 	"time"
 
 	"github.com/mmornati/leanproxy-mcp/pkg/errors"
+	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
 	"github.com/mmornati/leanproxy-mcp/pkg/utils"
 )
 
-type TransportType string
+type TransportType = migrate.TransportType
 
 const (
-	TransportStdio TransportType = "stdio"
-	TransportHTTP  TransportType = "http"
-	TransportSSE   TransportType = "sse"
+	TransportStdio = migrate.TransportStdio
+	TransportHTTP  = migrate.TransportHTTP
+	TransportSSE   = migrate.TransportSSE
 )
 
 type HealthStatus string


### PR DESCRIPTION
## Story 11.2 — \`leanproxy add <server-id>\` one-click install (FR41)

Closes the discovery loop from Story 11.1. After \`leanproxy marketplace sync\`,
users can now run \`leanproxy add <server-id>\` to:

1. Resolve the server id against the local registry cache (case-insensitive).
2. Print a **token-cost preview** (native vs. lean-proxy tokens, savings %,
   optional registry-declared \`tokensPerTurn\` budget note) **before** writing.
3. Merge the registry entry into \`leanproxy_servers.yaml\` (atomic write,
   0600 perms).
4. Gracefully stop any running instance that shares the target name (when
   \`--stop-existing\` is set, default \`true\`).
5. Surface up to **5 "did you mean" suggestions** via Levenshtein ranking
   for unknown ids.

### New surface

| File | Purpose |
| --- | --- |
| \`pkg/bouncer/snapshot.go\` | \`ComputeSnapshot(name, transport, tools, tokensPerTurn)\` → token-cost preview + \`FormatSnapshot\` for terminal output |
| \`pkg/migrate/installer.go\` | \`Installer{Resolve, Install, SaveConfig}\`, \`ServerSource\`, \`LifecycleStopper\`, \`ErrUnknownServer{Suggested}\`, \`ErrAlreadyInstalled\`, \`SuggestSimilar\`, Levenshtein |
| \`pkg/migrate/transport.go\` | \`TransportType\` + \`TransportStdio/HTTP/SSE\` now owned by pkg/migrate (breaks the import cycle that surfaced once \`pkg/registry\` began depending on \`pkg/migrate\`) |
| \`cmd/add.go\` | \`leanproxy add <server-id>\` (\`alias: install\`); flags \`--force\`, \`--yes/-y\`, \`--dry-run\`, \`--stop-existing\`, \`--graceful-wait\`; integrates with \`registry.FeedFetcher\` via \`feedSourceAdapter\` |

### Backward compatibility

- \`registry.TransportType\`, \`registry.TransportStdio\`, \`registry.TransportHTTP\`,
  \`registry.TransportSSE\` are now **Go type aliases** over the migrate
  package — every existing reference compiles unchanged.
- \`migrate.ServerConfig.Transport\` still serialises as the same string values
  (\`stdio\` / \`http\` / \`sse\`) so existing \`leanproxy_servers.yaml\` files
  are forward- and backward-compatible.
- The \`add\` server subcommand (\`leanproxy server add\`) used by existing
  migration flows is unchanged.

### Quality

- **1263 tests pass** with \`-race\` across 24 packages (up from 1221 before).
  New tests: 7 snapshot, 23 installer, 12 add-command.
- \`go vet ./...\` clean.
- \`gofmt -l\` clean across all new files.
- Static binary: **12.9 MB** (under the 20 MB target).

### Acceptance criteria coverage

| Criterion | Where |
| --- | --- |
| Registry synced + \`leanproxy add github\` → merge, schedule, success w/ tool count + token-cost preview | \`cmd/add.go:runAdd\` → \`migrate.Installer.Install\` → \`bouncer.ComputeSnapshot\` |
| Unknown server → list up to 5 similar, non-zero exit | \`ErrUnknownServer.Suggested\` populated by \`SuggestSimilar\` (Levenshtein), surfaced via \`cmd.ErrOrStderr()\` and a non-nil error |
| Existing name → prompt or \`--force\`, graceful stop first | Confirmation via \`fmt.Scanln\` (or \`--yes\`); \`--force\`; \`--stop-existing\` calls \`LifecycleStopper.Stop(ctx, id)\` with a configurable \`--graceful-wait\` |

### Test plan

\`\`\`bash
go test -race -timeout 5m ./...
go vet ./...
go build -o leanproxy-mcp .
\`\`\`

### Example

\`\`\`bash
$ leanproxy marketplace sync
$ leanproxy add github
Token-cost preview for github (stdio, ~3 tools): ~225 native tokens vs. 117 lean tokens (saves ~108 tokens / 48%)
Registry reports ~1500 tokens/turn baseline.

✓ Installed github (stdio)
  Config: /Users/me/.config/leanproxy_servers.yaml

$ leanproxy add gitub
Error: unknown server: "gitub" (did you mean: github)

Did you mean one of:
  leanproxy add github
\`\`\`