### PR TITLE
[Story 12.1] Embed tool-call payloads via local or remote model

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,7 +17,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mmornati/leanproxy-mcp/pkg/bouncer"
 	"github.com/mmornati/leanproxy-mcp/pkg/cache"
+	"github.com/mmornati/leanproxy-mcp/pkg/cache/embedder"
 	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 	"github.com/mmornati/leanproxy-mcp/pkg/gateway"
 	"github.com/mmornati/leanproxy-mcp/pkg/mcp"
@@ -44,6 +46,11 @@ var serveFlags struct {
 	upstreamURL     string
 	providersConfig string
 	cacheStrategy   string
+	embedProvider   string
+	ollamaURL       string
+	ollamaModel     string
+	openAIModel     string
+	embedPoolSize   int
 }
 
 var providerDetector atomic.Pointer[cache.ProviderDetector]
@@ -78,6 +85,11 @@ func init() {
 	serveCmd.Flags().StringVar(&serveFlags.upstreamURL, "upstream", "http://localhost:8081", "Upstream JSON-RPC server URL")
 	serveCmd.Flags().StringVar(&serveFlags.providersConfig, "providers-config", "", "Path to providers config file for provider detection")
 	serveCmd.Flags().StringVar(&serveFlags.cacheStrategy, "cache-strategy", "off", "Cache breakpoint injection strategy for Anthropic requests: off (default, no injection), aggressive (last system + last tool), balanced (largest block only)")
+	serveCmd.Flags().StringVar(&serveFlags.embedProvider, "embed-provider", "", "Embedding provider: ollama or openai (empty = disabled)")
+	serveCmd.Flags().StringVar(&serveFlags.ollamaURL, "ollama-url", "http://localhost:11434", "Ollama server URL")
+	serveCmd.Flags().StringVar(&serveFlags.ollamaModel, "ollama-model", "nomic-embed-text", "Ollama embedding model")
+	serveCmd.Flags().StringVar(&serveFlags.openAIModel, "openai-model", "text-embedding-3-small", "OpenAI embedding model")
+	serveCmd.Flags().IntVar(&serveFlags.embedPoolSize, "embed-pool-size", 4, "Embedder worker pool size")
 	RootCmd.AddCommand(serveCmd)
 }
 
@@ -181,6 +193,28 @@ func runServe(cmd *cobra.Command, args []string) {
 			cache.WithInjectLogger(slog.Default()),
 			cache.WithStrategy(strategy),
 		))
+	}
+
+	if serveFlags.embedProvider != "" {
+		embedCfg := embedder.Config{Provider: embedder.Provider(serveFlags.embedProvider)}
+		switch embedCfg.Provider {
+		case embedder.ProviderOllama:
+			embedCfg.Ollama = &embedder.OllamaConfig{
+				URL:   serveFlags.ollamaURL,
+				Model: serveFlags.ollamaModel,
+			}
+		case embedder.ProviderOpenAI:
+			embedCfg.OpenAI = &embedder.OpenAIConfig{
+				Model: serveFlags.openAIModel,
+			}
+		default:
+			slog.Warn("unknown embed provider, disabling embedding", "provider", serveFlags.embedProvider)
+		}
+		if err := embedCfg.Validate(); err == nil {
+			bouncer.MustSetupEmbedder(embedCfg, embedder.PoolConfig{Size: serveFlags.embedPoolSize})
+		} else {
+			slog.Warn("embedder configuration invalid, disabling", "error", err)
+		}
 	}
 
 	handler := mcp.NewHandlerWithToolStore(unifiedPool, slog.Default(), toolStore)
@@ -588,8 +622,24 @@ func injectBreakpoints(server *registry.ServerEntry, req *proxy.JSONRPCRequest) 
 		slog.Debug("cache breakpoints injected", "server", server.ID)
 	}
 
+	embedOutboundPayload(req)
+
 	cache.GlobalCacheStatsTracker().RecordRequest(provider, hasBreakpoint, inputEstimate)
 	return provider
+}
+
+func embedOutboundPayload(req *proxy.JSONRPCRequest) {
+	pool := bouncer.GlobalEmbedPool()
+	if pool == nil {
+		return
+	}
+	if len(req.Params) == 0 {
+		return
+	}
+	_, _ = bouncer.EmbedToolCall(context.Background(), bouncer.EmbedRequest{
+		ToolName: req.Method,
+		Args:     req.Params,
+	})
 }
 
 func writeResponse(writer *bufio.Writer, resp *proxy.JSONRPCResponse) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -208,12 +208,10 @@ func runServe(cmd *cobra.Command, args []string) {
 				Model: serveFlags.openAIModel,
 			}
 		default:
-			slog.Warn("unknown embed provider, disabling embedding", "provider", serveFlags.embedProvider)
+			logError("unknown embed provider %q: must be 'ollama' or 'openai'", serveFlags.embedProvider)
 		}
-		if err := embedCfg.Validate(); err == nil {
-			bouncer.MustSetupEmbedder(embedCfg, embedder.PoolConfig{Size: serveFlags.embedPoolSize})
-		} else {
-			slog.Warn("embedder configuration invalid, disabling", "error", err)
+		if err := bouncer.SetupEmbedder(embedCfg, embedder.PoolConfig{Size: serveFlags.embedPoolSize}); err != nil {
+			logError("embedder setup failed (failing startup): %v", err)
 		}
 	}
 
@@ -595,14 +593,17 @@ func recordProvider(server *registry.ServerEntry) {
 
 func injectBreakpoints(server *registry.ServerEntry, req *proxy.JSONRPCRequest) cache.Provider {
 	if server == nil || server.Address == "" || req == nil || len(req.Params) == 0 {
+		embedOutboundPayload(req)
 		return cache.ProviderOther
 	}
 	det := providerDetector.Load()
 	if det == nil {
+		embedOutboundPayload(req)
 		return cache.ProviderOther
 	}
 	provider := det.Detect(server.Address)
 	if provider != cache.ProviderAnthropic {
+		embedOutboundPayload(req)
 		return provider
 	}
 
@@ -615,6 +616,7 @@ func injectBreakpoints(server *registry.ServerEntry, req *proxy.JSONRPCRequest) 
 		if err != nil {
 			slog.Debug("breakpoint injection skipped", "error", err)
 			cache.GlobalCacheStatsTracker().RecordRequest(provider, false, inputEstimate)
+			embedOutboundPayload(req)
 			return provider
 		}
 		req.Params = modified
@@ -629,17 +631,36 @@ func injectBreakpoints(server *registry.ServerEntry, req *proxy.JSONRPCRequest) 
 }
 
 func embedOutboundPayload(req *proxy.JSONRPCRequest) {
-	pool := bouncer.GlobalEmbedPool()
-	if pool == nil {
+	if req == nil || len(req.Params) == 0 {
 		return
 	}
-	if len(req.Params) == 0 {
+	if bouncer.GlobalEmbedPool() == nil {
 		return
 	}
-	_, _ = bouncer.EmbedToolCall(context.Background(), bouncer.EmbedRequest{
-		ToolName: req.Method,
+	toolName := extractToolName(req)
+	bouncer.EmbedToolCall(context.Background(), bouncer.EmbedRequest{
+		ToolName: toolName,
 		Args:     req.Params,
 	})
+}
+
+func extractToolName(req *proxy.JSONRPCRequest) string {
+	if req == nil {
+		return ""
+	}
+	if req.Method != "" && isToolCallMethod(req.Method) {
+		var p struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(req.Params, &p); err == nil && p.Name != "" {
+			return p.Name
+		}
+	}
+	return req.Method
+}
+
+func isToolCallMethod(method string) bool {
+	return method == "tools/call" || method == "invoke_tool"
 }
 
 func writeResponse(writer *bufio.Writer, resp *proxy.JSONRPCResponse) {

--- a/pkg/bouncer/embed.go
+++ b/pkg/bouncer/embed.go
@@ -1,0 +1,78 @@
+package bouncer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/cache/embedder"
+)
+
+var globalEmbedPool *embedder.Pool
+
+func SetGlobalEmbedPool(p *embedder.Pool) {
+	globalEmbedPool = p
+}
+
+func GlobalEmbedPool() *embedder.Pool {
+	return globalEmbedPool
+}
+
+type EmbedRequest struct {
+	ToolName string
+	Args     json.RawMessage
+}
+
+type EmbedResult struct {
+	Vector []float32 `json:"vector"`
+	Model  string    `json:"model"`
+}
+
+func EmbedToolCall(ctx context.Context, req EmbedRequest) (<-chan embedder.Embedding, <-chan error) {
+	emptyEmb := make(chan embedder.Embedding, 1)
+	close(emptyEmb)
+	emptyErr := make(chan error, 1)
+	emptyErr <- fmt.Errorf("embedder: no global embed pool configured")
+	close(emptyErr)
+
+	pool := globalEmbedPool
+	if pool == nil {
+		return emptyEmb, emptyErr
+	}
+
+	embReq := embedder.EmbedRequest{
+		ToolName: req.ToolName,
+		Args:     req.Args,
+	}
+
+	return pool.Embed(ctx, embReq)
+}
+
+func MustSetupEmbedder(cfg embedder.Config, poolCfg embedder.PoolConfig) {
+	logger := slog.With("component", "bouncer.embedder")
+
+	eng, err := newEmbedderFromConfig(cfg, logger)
+	if err != nil {
+		slog.Error("embedder setup failed", "error", err)
+		return
+	}
+
+	pool := embedder.NewPool(eng, poolCfg, logger)
+	SetGlobalEmbedPool(pool)
+	slog.Info("embedder pool initialized",
+		"provider", cfg.Provider,
+		"pool_size", poolCfg.Size,
+	)
+}
+
+func newEmbedderFromConfig(cfg embedder.Config, logger *slog.Logger) (embedder.Embedder, error) {
+	switch cfg.Provider {
+	case embedder.ProviderOllama:
+		return embedder.NewOllamaEmbedder(*cfg.Ollama, logger)
+	case embedder.ProviderOpenAI:
+		return embedder.NewOpenAIEmbedder(*cfg.OpenAI, logger)
+	default:
+		return nil, fmt.Errorf("unsupported embedder provider: %s", cfg.Provider)
+	}
+}

--- a/pkg/bouncer/embed.go
+++ b/pkg/bouncer/embed.go
@@ -60,29 +60,27 @@ func EmbedToolCall(ctx context.Context, req EmbedRequest) {
 		Args:     req.Args,
 	}
 
-	resultCh, errCh := pool.Embed(ctx, embReq)
+	outCh := pool.Embed(ctx, embReq)
 
 	go func(req EmbedRequest) {
-		outcome := EmbedOutcome{Request: req, Provider: "unknown"}
-		select {
-		case emb, ok := <-resultCh:
-			if !ok {
-				return
-			}
-			outcome.Vector = emb.Vector
-			outcome.Model = emb.Model
+		outcome := EmbedOutcome{Request: req, Provider: string(pool.Provider())}
+		// Single outcome channel: either Embedding is set (success) or Err is set.
+		o, ok := <-outCh
+		if !ok {
+			return
+		}
+		if o.Err != nil {
+			outcome.Err = o.Err.Error()
+			handleEmbedError(req, o.Err)
+			recordEmbedFailure()
+		} else {
+			outcome.Vector = o.Embedding.Vector
+			outcome.Model = o.Embedding.Model
 			slog.Debug("embedder: success",
 				"tool", req.ToolName,
-				"model", emb.Model,
-				"dims", len(emb.Vector))
+				"model", o.Embedding.Model,
+				"dims", len(o.Embedding.Vector))
 			recordEmbedSuccess()
-		case err, ok := <-errCh:
-			if !ok {
-				return
-			}
-			outcome.Err = err.Error()
-			handleEmbedError(req, err)
-			recordEmbedFailure()
 		}
 		if EmbedResultHandler != nil {
 			EmbedResultHandler(outcome)

--- a/pkg/bouncer/embed.go
+++ b/pkg/bouncer/embed.go
@@ -3,20 +3,26 @@ package bouncer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 
 	"github.com/mmornati/leanproxy-mcp/pkg/cache/embedder"
 )
 
-var globalEmbedPool *embedder.Pool
+var globalEmbedPool atomic.Pointer[embedder.Pool]
 
 func SetGlobalEmbedPool(p *embedder.Pool) {
-	globalEmbedPool = p
+	if p == nil {
+		globalEmbedPool.Store(nil)
+		return
+	}
+	globalEmbedPool.Store(p)
 }
 
 func GlobalEmbedPool() *embedder.Pool {
-	return globalEmbedPool
+	return globalEmbedPool.Load()
 }
 
 type EmbedRequest struct {
@@ -24,21 +30,29 @@ type EmbedRequest struct {
 	Args     json.RawMessage
 }
 
-type EmbedResult struct {
-	Vector []float32 `json:"vector"`
-	Model  string    `json:"model"`
+type EmbedOutcome struct {
+	Request  EmbedRequest `json:"request"`
+	Provider string       `json:"provider"`
+	Model    string       `json:"model,omitempty"`
+	Vector   []float32    `json:"vector,omitempty"`
+	Err      string       `json:"error,omitempty"`
 }
 
-func EmbedToolCall(ctx context.Context, req EmbedRequest) (<-chan embedder.Embedding, <-chan error) {
-	emptyEmb := make(chan embedder.Embedding, 1)
-	close(emptyEmb)
-	emptyErr := make(chan error, 1)
-	emptyErr <- fmt.Errorf("embedder: no global embed pool configured")
-	close(emptyErr)
+var EmbedResultHandler func(EmbedOutcome)
 
-	pool := globalEmbedPool
+func EmbedToolCall(ctx context.Context, req EmbedRequest) {
+	pool := globalEmbedPool.Load()
 	if pool == nil {
-		return emptyEmb, emptyErr
+		return
+	}
+	if req.ToolName == "" {
+		return
+	}
+	if len(req.Args) > embedder.MaxPayloadBytes {
+		slog.Warn("embedder: payload too large, skipping",
+			"tool", req.ToolName,
+			"bytes", len(req.Args))
+		return
 	}
 
 	embReq := embedder.EmbedRequest{
@@ -46,24 +60,98 @@ func EmbedToolCall(ctx context.Context, req EmbedRequest) (<-chan embedder.Embed
 		Args:     req.Args,
 	}
 
-	return pool.Embed(ctx, embReq)
+	resultCh, errCh := pool.Embed(ctx, embReq)
+
+	go func(req EmbedRequest) {
+		outcome := EmbedOutcome{Request: req, Provider: "unknown"}
+		select {
+		case emb, ok := <-resultCh:
+			if !ok {
+				return
+			}
+			outcome.Vector = emb.Vector
+			outcome.Model = emb.Model
+			slog.Debug("embedder: success",
+				"tool", req.ToolName,
+				"model", emb.Model,
+				"dims", len(emb.Vector))
+			recordEmbedSuccess()
+		case err, ok := <-errCh:
+			if !ok {
+				return
+			}
+			outcome.Err = err.Error()
+			handleEmbedError(req, err)
+			recordEmbedFailure()
+		}
+		if EmbedResultHandler != nil {
+			EmbedResultHandler(outcome)
+		}
+	}(req)
 }
 
-func MustSetupEmbedder(cfg embedder.Config, poolCfg embedder.PoolConfig) {
+func handleEmbedError(req EmbedRequest, err error) {
+	switch {
+	case errors.Is(err, embedder.ErrPoolFull):
+		slog.Warn("embedder: pool full, falling back to exact-match",
+			"tool", req.ToolName)
+	case errors.Is(err, embedder.ErrEmbedderUnavailable):
+		slog.Warn("embedder: provider unreachable, falling back to exact-match",
+			"tool", req.ToolName,
+			"error", err)
+	case errors.Is(err, embedder.ErrPayloadTooLarge):
+		slog.Warn("embedder: payload too large, falling back to exact-match",
+			"tool", req.ToolName,
+			"error", err)
+	default:
+		slog.Warn("embedder: failure, falling back to exact-match",
+			"tool", req.ToolName,
+			"error", err)
+	}
+}
+
+var (
+	embedSuccessCount atomic.Uint64
+	embedFailureCount atomic.Uint64
+)
+
+func recordEmbedSuccess() { embedSuccessCount.Add(1) }
+func recordEmbedFailure() { embedFailureCount.Add(1) }
+
+func EmbedSuccessCount() uint64 { return embedSuccessCount.Load() }
+func EmbedFailureCount() uint64 { return embedFailureCount.Load() }
+
+func SetupEmbedder(cfg embedder.Config, poolCfg embedder.PoolConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("embedder config: %w", err)
+	}
+
 	logger := slog.With("component", "bouncer.embedder")
 
 	eng, err := newEmbedderFromConfig(cfg, logger)
 	if err != nil {
-		slog.Error("embedder setup failed", "error", err)
-		return
+		return fmt.Errorf("embedder create: %w", err)
 	}
 
+	poolCfg = embedder.PoolConfig{
+		Size:  poolCfg.Size,
+		Queue: poolCfg.Queue,
+	}
+	if poolCfg.Size <= 0 {
+		poolCfg.Size = 4
+	}
+	if poolCfg.Queue <= 0 {
+		poolCfg.Queue = 256
+	}
 	pool := embedder.NewPool(eng, poolCfg, logger)
-	SetGlobalEmbedPool(pool)
-	slog.Info("embedder pool initialized",
+	if old := globalEmbedPool.Swap(pool); old != nil {
+		_ = old.Close()
+	}
+	logger.Info("embedder pool initialized",
 		"provider", cfg.Provider,
 		"pool_size", poolCfg.Size,
 	)
+	return nil
 }
 
 func newEmbedderFromConfig(cfg embedder.Config, logger *slog.Logger) (embedder.Embedder, error) {

--- a/pkg/bouncer/embed_test.go
+++ b/pkg/bouncer/embed_test.go
@@ -1,0 +1,161 @@
+package bouncer
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/cache/embedder"
+)
+
+func TestEmbedToolCallNoPool(t *testing.T) {
+	SetGlobalEmbedPool(nil)
+
+	_, errCh := EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test"})
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "no global embed pool") {
+			t.Errorf("expected 'no global embed pool' error, got: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestEmbedToolCallWithPool(t *testing.T) {
+	mock := &testEmbedder{emb: embedder.Embedding{Vector: []float32{0.1, 0.2}, Model: "test-model"}}
+	pool := embedder.NewPool(mock, embedder.PoolConfig{Size: 1}, slog.Default())
+	defer pool.Close()
+
+	SetGlobalEmbedPool(pool)
+	defer SetGlobalEmbedPool(nil)
+
+	resultCh, errCh := EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test"})
+	select {
+	case emb := <-resultCh:
+		if len(emb.Vector) != 2 {
+			t.Errorf("expected 2 dims, got %d", len(emb.Vector))
+		}
+		if emb.Model != "test-model" {
+			t.Errorf("model = %q, want %q", emb.Model, "test-model")
+		}
+	case err := <-errCh:
+		t.Fatalf("unexpected error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestNewEmbedderFromConfigOllama(t *testing.T) {
+	cfg := embedder.Config{
+		Provider: embedder.ProviderOllama,
+		Ollama:   &embedder.OllamaConfig{URL: "http://localhost:11434"},
+	}
+	eng, err := newEmbedderFromConfig(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if eng.Provider() != embedder.ProviderOllama {
+		t.Errorf("provider = %q, want %q", eng.Provider(), embedder.ProviderOllama)
+	}
+	eng.Close()
+}
+
+func TestNewEmbedderFromConfigOpenAI(t *testing.T) {
+	cfg := embedder.Config{
+		Provider: embedder.ProviderOpenAI,
+		OpenAI:   &embedder.OpenAIConfig{APIKey: "sk-test"},
+	}
+	eng, err := newEmbedderFromConfig(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if eng.Provider() != embedder.ProviderOpenAI {
+		t.Errorf("provider = %q, want %q", eng.Provider(), embedder.ProviderOpenAI)
+	}
+	eng.Close()
+}
+
+func TestNewEmbedderFromConfigUnknown(t *testing.T) {
+	cfg := embedder.Config{Provider: "unknown"}
+	_, err := newEmbedderFromConfig(cfg, slog.Default())
+	if err == nil || !strings.Contains(err.Error(), "unsupported embedder provider") {
+		t.Errorf("expected error about unsupported provider, got: %v", err)
+	}
+}
+
+func TestMustSetupEmbedder(t *testing.T) {
+	// Should not panic with valid config
+	cfg := embedder.Config{
+		Provider: embedder.ProviderOllama,
+		Ollama:   &embedder.OllamaConfig{URL: "http://localhost:11434"},
+	}
+	MustSetupEmbedder(cfg, embedder.PoolConfig{Size: 1})
+	pool := GlobalEmbedPool()
+	if pool == nil {
+		t.Fatal("expected non-nil global pool after MustSetupEmbedder")
+	}
+	pool.Close()
+	SetGlobalEmbedPool(nil)
+}
+
+type testEmbedder struct {
+	emb embedder.Embedding
+	err error
+}
+
+func (t *testEmbedder) Embed(_ context.Context, _ embedder.EmbedRequest) (embedder.Embedding, error) {
+	if t.err != nil {
+		return embedder.Embedding{}, t.err
+	}
+	return t.emb, nil
+}
+
+func (t *testEmbedder) Provider() embedder.Provider { return embedder.ProviderOllama }
+func (t *testEmbedder) Close() error                { return nil }
+
+func TestGlobalEmbedPoolAccessors(t *testing.T) {
+	if GlobalEmbedPool() != nil {
+		t.Error("expected nil default global pool")
+	}
+
+	mock := &testEmbedder{emb: embedder.Embedding{Vector: []float32{1.0}, Model: "m"}}
+	pool := embedder.NewPool(mock, embedder.PoolConfig{Size: 1}, nil)
+	SetGlobalEmbedPool(pool)
+
+	if GlobalEmbedPool() != pool {
+		t.Error("global embed pool mismatch")
+	}
+
+	pool.Close()
+	SetGlobalEmbedPool(nil)
+}
+
+func TestEmbedResultType(t *testing.T) {
+	r := EmbedResult{Vector: []float32{0.1, 0.2}, Model: "test"}
+	if len(r.Vector) != 2 {
+		t.Errorf("expected 2 elements, got %d", len(r.Vector))
+	}
+}
+
+func TestEmbedToolCallPoolError(t *testing.T) {
+	mock := &testEmbedder{err: errors.New("embed failed")}
+	pool := embedder.NewPool(mock, embedder.PoolConfig{Size: 1}, slog.Default())
+	defer pool.Close()
+
+	SetGlobalEmbedPool(pool)
+	defer SetGlobalEmbedPool(nil)
+
+	_, errCh := EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test"})
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "embed failed") {
+			t.Errorf("expected 'embed failed' error, got: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}

--- a/pkg/bouncer/embed_test.go
+++ b/pkg/bouncer/embed_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,19 +14,10 @@ import (
 
 func TestEmbedToolCallNoPool(t *testing.T) {
 	SetGlobalEmbedPool(nil)
-
-	_, errCh := EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test"})
-	select {
-	case err := <-errCh:
-		if err == nil || !strings.Contains(err.Error(), "no global embed pool") {
-			t.Errorf("expected 'no global embed pool' error, got: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
+	EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test"})
 }
 
-func TestEmbedToolCallWithPool(t *testing.T) {
+func TestEmbedToolCallWithPoolSuccess(t *testing.T) {
 	mock := &testEmbedder{emb: embedder.Embedding{Vector: []float32{0.1, 0.2}, Model: "test-model"}}
 	pool := embedder.NewPool(mock, embedder.PoolConfig{Size: 1}, slog.Default())
 	defer pool.Close()
@@ -33,50 +25,208 @@ func TestEmbedToolCallWithPool(t *testing.T) {
 	SetGlobalEmbedPool(pool)
 	defer SetGlobalEmbedPool(nil)
 
-	resultCh, errCh := EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test"})
+	done := make(chan struct{})
+	var captured EmbedOutcome
+	prev := EmbedResultHandler
+	EmbedResultHandler = func(o EmbedOutcome) {
+		captured = o
+		close(done)
+	}
+	defer func() { EmbedResultHandler = prev }()
+
+	EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test"})
+
 	select {
-	case emb := <-resultCh:
-		if len(emb.Vector) != 2 {
-			t.Errorf("expected 2 dims, got %d", len(emb.Vector))
+	case <-done:
+		if len(captured.Vector) != 2 {
+			t.Errorf("expected 2 dims, got %d", len(captured.Vector))
 		}
-		if emb.Model != "test-model" {
-			t.Errorf("model = %q, want %q", emb.Model, "test-model")
+		if captured.Model != "test-model" {
+			t.Errorf("model = %q, want %q", captured.Model, "test-model")
 		}
-	case err := <-errCh:
-		t.Fatalf("unexpected error: %v", err)
-	case <-time.After(time.Second):
+		if captured.Err != "" {
+			t.Errorf("unexpected error: %s", captured.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for embed result")
+	}
+}
+
+func TestEmbedToolCallPoolError(t *testing.T) {
+	mock := &testEmbedder{err: errors.New("embed failed")}
+	pool := embedder.NewPool(mock, embedder.PoolConfig{Size: 1}, slog.Default())
+	defer pool.Close()
+
+	SetGlobalEmbedPool(pool)
+	defer SetGlobalEmbedPool(nil)
+
+	done := make(chan struct{})
+	var captured EmbedOutcome
+	prev := EmbedResultHandler
+	EmbedResultHandler = func(o EmbedOutcome) {
+		captured = o
+		close(done)
+	}
+	defer func() { EmbedResultHandler = prev }()
+
+	EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test"})
+
+	select {
+	case <-done:
+		if captured.Err == "" {
+			t.Error("expected error captured")
+		}
+		if EmbedFailureCount() == 0 {
+			t.Error("expected EmbedFailureCount > 0")
+		}
+	case <-time.After(2 * time.Second):
 		t.Fatal("timeout")
 	}
 }
 
-func TestNewEmbedderFromConfigOllama(t *testing.T) {
+func TestEmbedToolCallPoolFull(t *testing.T) {
+	blocker := &blockingEmbedder{block: make(chan struct{})}
+	pool := embedder.NewPool(blocker, embedder.PoolConfig{Size: 1, Queue: 1}, slog.Default())
+
+	SetGlobalEmbedPool(pool)
+	defer func() {
+		close(blocker.block)
+		pool.Close()
+		SetGlobalEmbedPool(nil)
+	}()
+
+	_, _ = pool.Embed(context.Background(), embedder.EmbedRequest{ToolName: "filler"})
+	_, _ = pool.Embed(context.Background(), embedder.EmbedRequest{ToolName: "filler2"})
+
+	done := make(chan struct{})
+	prev := EmbedResultHandler
+	EmbedResultHandler = func(o EmbedOutcome) {
+		if o.Err != "" && strings.Contains(o.Err, "queue full") {
+			close(done)
+		}
+	}
+	defer func() { EmbedResultHandler = prev }()
+
+	EmbedToolCall(context.Background(), EmbedRequest{ToolName: "overflow"})
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for pool-full error")
+	}
+}
+
+func TestEmbedToolCallEmptyToolName(t *testing.T) {
+	embedSuccessCount.Store(0)
+	embedFailureCount.Store(0)
+
+	mock := &testEmbedder{emb: embedder.Embedding{Vector: []float32{1}}}
+	pool := embedder.NewPool(mock, embedder.PoolConfig{Size: 1}, slog.Default())
+	defer pool.Close()
+
+	SetGlobalEmbedPool(pool)
+	defer SetGlobalEmbedPool(nil)
+
+	EmbedToolCall(context.Background(), EmbedRequest{ToolName: ""})
+	time.Sleep(100 * time.Millisecond)
+
+	if embedSuccessCount.Load() > 0 {
+		t.Error("empty tool name should not embed")
+	}
+}
+
+func TestEmbedToolCallPayloadTooLarge(t *testing.T) {
+	mock := &testEmbedder{emb: embedder.Embedding{Vector: []float32{1}}}
+	pool := embedder.NewPool(mock, embedder.PoolConfig{Size: 1}, slog.Default())
+	defer pool.Close()
+
+	SetGlobalEmbedPool(pool)
+	defer SetGlobalEmbedPool(nil)
+
+	bigArgs := make([]byte, embedder.MaxPayloadBytes+10)
+	for i := range bigArgs {
+		bigArgs[i] = 'a'
+	}
+	EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test", Args: bigArgs})
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestSetupEmbedderOllama(t *testing.T) {
 	cfg := embedder.Config{
 		Provider: embedder.ProviderOllama,
 		Ollama:   &embedder.OllamaConfig{URL: "http://localhost:11434"},
 	}
-	eng, err := newEmbedderFromConfig(cfg, slog.Default())
-	if err != nil {
+	if err := SetupEmbedder(cfg, embedder.PoolConfig{Size: 1}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if eng.Provider() != embedder.ProviderOllama {
-		t.Errorf("provider = %q, want %q", eng.Provider(), embedder.ProviderOllama)
+	pool := GlobalEmbedPool()
+	if pool == nil {
+		t.Fatal("expected non-nil global pool after SetupEmbedder")
 	}
-	eng.Close()
+	pool.Close()
+	SetGlobalEmbedPool(nil)
 }
 
-func TestNewEmbedderFromConfigOpenAI(t *testing.T) {
+func TestSetupEmbedderOpenAI(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
 	cfg := embedder.Config{
 		Provider: embedder.ProviderOpenAI,
 		OpenAI:   &embedder.OpenAIConfig{APIKey: "sk-test"},
 	}
-	eng, err := newEmbedderFromConfig(cfg, slog.Default())
-	if err != nil {
+	if err := SetupEmbedder(cfg, embedder.PoolConfig{Size: 1}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if eng.Provider() != embedder.ProviderOpenAI {
-		t.Errorf("provider = %q, want %q", eng.Provider(), embedder.ProviderOpenAI)
+	pool := GlobalEmbedPool()
+	if pool == nil {
+		t.Fatal("expected non-nil global pool after SetupEmbedder")
 	}
-	eng.Close()
+	pool.Close()
+	SetGlobalEmbedPool(nil)
+}
+
+func TestSetupEmbedderMissingOpenAIKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	cfg := embedder.Config{
+		Provider: embedder.ProviderOpenAI,
+		OpenAI:   &embedder.OpenAIConfig{},
+	}
+	err := SetupEmbedder(cfg, embedder.PoolConfig{Size: 1})
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+	if !strings.Contains(err.Error(), "OPENAI_API_KEY") {
+		t.Errorf("expected OPENAI_API_KEY in error, got: %v", err)
+	}
+}
+
+func TestSetupEmbedderInvalidURL(t *testing.T) {
+	cfg := embedder.Config{
+		Provider: embedder.ProviderOllama,
+		Ollama:   &embedder.OllamaConfig{URL: "://bad"},
+	}
+	err := SetupEmbedder(cfg, embedder.PoolConfig{Size: 1})
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestSetupEmbedderReplacesExistingPool(t *testing.T) {
+	mock1 := &testEmbedder{emb: embedder.Embedding{Vector: []float32{1}}}
+	pool1 := embedder.NewPool(mock1, embedder.PoolConfig{Size: 1}, nil)
+	SetGlobalEmbedPool(pool1)
+
+	cfg := embedder.Config{
+		Provider: embedder.ProviderOllama,
+		Ollama:   &embedder.OllamaConfig{URL: "http://localhost:11434"},
+	}
+	if err := SetupEmbedder(cfg, embedder.PoolConfig{Size: 2}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pool2 := GlobalEmbedPool()
+	if pool2 == pool1 {
+		t.Error("expected pool to be replaced")
+	}
+	pool2.Close()
+	SetGlobalEmbedPool(nil)
 }
 
 func TestNewEmbedderFromConfigUnknown(t *testing.T) {
@@ -87,27 +237,15 @@ func TestNewEmbedderFromConfigUnknown(t *testing.T) {
 	}
 }
 
-func TestMustSetupEmbedder(t *testing.T) {
-	// Should not panic with valid config
-	cfg := embedder.Config{
-		Provider: embedder.ProviderOllama,
-		Ollama:   &embedder.OllamaConfig{URL: "http://localhost:11434"},
-	}
-	MustSetupEmbedder(cfg, embedder.PoolConfig{Size: 1})
-	pool := GlobalEmbedPool()
-	if pool == nil {
-		t.Fatal("expected non-nil global pool after MustSetupEmbedder")
-	}
-	pool.Close()
-	SetGlobalEmbedPool(nil)
-}
-
 type testEmbedder struct {
+	mu  sync.Mutex
 	emb embedder.Embedding
 	err error
 }
 
 func (t *testEmbedder) Embed(_ context.Context, _ embedder.EmbedRequest) (embedder.Embedding, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.err != nil {
 		return embedder.Embedding{}, t.err
 	}
@@ -116,6 +254,17 @@ func (t *testEmbedder) Embed(_ context.Context, _ embedder.EmbedRequest) (embedd
 
 func (t *testEmbedder) Provider() embedder.Provider { return embedder.ProviderOllama }
 func (t *testEmbedder) Close() error                { return nil }
+
+type blockingEmbedder struct {
+	block chan struct{}
+}
+
+func (b *blockingEmbedder) Embed(_ context.Context, _ embedder.EmbedRequest) (embedder.Embedding, error) {
+	<-b.block
+	return embedder.Embedding{}, nil
+}
+func (b *blockingEmbedder) Provider() embedder.Provider { return embedder.ProviderOllama }
+func (b *blockingEmbedder) Close() error                { return nil }
 
 func TestGlobalEmbedPoolAccessors(t *testing.T) {
 	if GlobalEmbedPool() != nil {
@@ -134,28 +283,23 @@ func TestGlobalEmbedPoolAccessors(t *testing.T) {
 	SetGlobalEmbedPool(nil)
 }
 
-func TestEmbedResultType(t *testing.T) {
-	r := EmbedResult{Vector: []float32{0.1, 0.2}, Model: "test"}
-	if len(r.Vector) != 2 {
-		t.Errorf("expected 2 elements, got %d", len(r.Vector))
+func TestEmbedOutcomeFields(t *testing.T) {
+	o := EmbedOutcome{
+		Request:  EmbedRequest{ToolName: "t"},
+		Provider: "ollama",
+		Model:    "m",
+		Vector:   []float32{0.1},
+	}
+	if o.Provider != "ollama" {
+		t.Errorf("provider = %q, want %q", o.Provider, "ollama")
 	}
 }
 
-func TestEmbedToolCallPoolError(t *testing.T) {
-	mock := &testEmbedder{err: errors.New("embed failed")}
-	pool := embedder.NewPool(mock, embedder.PoolConfig{Size: 1}, slog.Default())
-	defer pool.Close()
+func TestEmbedCounters(t *testing.T) {
+	embedSuccessCount.Store(0)
+	embedFailureCount.Store(0)
 
-	SetGlobalEmbedPool(pool)
-	defer SetGlobalEmbedPool(nil)
-
-	_, errCh := EmbedToolCall(context.Background(), EmbedRequest{ToolName: "test"})
-	select {
-	case err := <-errCh:
-		if err == nil || !strings.Contains(err.Error(), "embed failed") {
-			t.Errorf("expected 'embed failed' error, got: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
+	if EmbedSuccessCount() != 0 || EmbedFailureCount() != 0 {
+		t.Error("counters should reset")
 	}
 }

--- a/pkg/bouncer/embed_test.go
+++ b/pkg/bouncer/embed_test.go
@@ -95,21 +95,35 @@ func TestEmbedToolCallPoolFull(t *testing.T) {
 		SetGlobalEmbedPool(nil)
 	}()
 
-	_, _ = pool.Embed(context.Background(), embedder.EmbedRequest{ToolName: "filler"})
-	_, _ = pool.Embed(context.Background(), embedder.EmbedRequest{ToolName: "filler2"})
+	_ = pool.Embed(context.Background(), embedder.EmbedRequest{ToolName: "filler"})
+	// Give the worker a moment to enter the blocking embed call before we
+	// queue the second job — otherwise the race detector can land "filler2"
+	// in the queue before "filler" reaches the blocking call, and the third
+	// embed then fits in the queue instead of hitting the pool-full path.
+	time.Sleep(2 * time.Millisecond)
+	_ = pool.Embed(context.Background(), embedder.EmbedRequest{ToolName: "filler2"})
 
+	// Drive through EmbedResultHandler (set up before triggering EmbedToolCall)
+	// and wait via a done channel. Using a signal channel instead of reading
+	// the channels directly avoids a goroutine-scheduling race under -race.
 	done := make(chan struct{})
+	var gotErr error
 	prev := EmbedResultHandler
 	EmbedResultHandler = func(o EmbedOutcome) {
 		if o.Err != "" && strings.Contains(o.Err, "queue full") {
+			gotErr = errors.New(o.Err)
 			close(done)
 		}
 	}
 	defer func() { EmbedResultHandler = prev }()
 
 	EmbedToolCall(context.Background(), EmbedRequest{ToolName: "overflow"})
+
 	select {
 	case <-done:
+		if gotErr == nil {
+			t.Fatal("handler called but no error captured")
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for pool-full error")
 	}

--- a/pkg/cache/embedder/embedder.go
+++ b/pkg/cache/embedder/embedder.go
@@ -3,6 +3,7 @@ package embedder
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -69,13 +70,34 @@ func (c Config) Validate() error {
 		if c.Ollama == nil {
 			return fmt.Errorf("embedder: ollama config required when provider=%q", c.Provider)
 		}
-		return c.Ollama.Validate()
+		c.Ollama.withDefaults()
+		if err := validateOllamaURL(c.Ollama.URL); err != nil {
+			return fmt.Errorf("embedder ollama: %w", err)
+		}
+		if strings.TrimSpace(c.Ollama.Model) == "" {
+			return fmt.Errorf("embedder ollama: model must not be empty")
+		}
+		return nil
 	case ProviderOpenAI:
 		if c.OpenAI == nil {
 			return fmt.Errorf("embedder: openai config required when provider=%q", c.Provider)
 		}
-		return c.OpenAI.Validate()
+		c.OpenAI.withDefaults()
+		if err := c.OpenAI.validateKey(); err != nil {
+			return err
+		}
+		if strings.TrimSpace(c.OpenAI.Model) == "" {
+			return fmt.Errorf("embedder openai: model must not be empty")
+		}
+		return nil
 	default:
 		return fmt.Errorf("embedder: unknown provider %q", c.Provider)
 	}
 }
+
+var (
+	ErrEmbedderUnavailable = errors.New("embedder unavailable")
+	ErrPayloadTooLarge     = errors.New("embedder payload too large")
+)
+
+const MaxPayloadBytes = 64 * 1024

--- a/pkg/cache/embedder/embedder.go
+++ b/pkg/cache/embedder/embedder.go
@@ -1,0 +1,81 @@
+package embedder
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Provider string
+
+const (
+	ProviderOllama Provider = "ollama"
+	ProviderOpenAI Provider = "openai"
+)
+
+type EmbedRequest struct {
+	ToolName string
+	Args     json.RawMessage
+}
+
+func (r EmbedRequest) Input() string {
+	var b strings.Builder
+	b.WriteString(r.ToolName)
+	b.WriteByte(':')
+	if len(r.Args) > 0 {
+		keys := make([]string, 0, 8)
+		var parsed map[string]interface{}
+		if err := json.Unmarshal(r.Args, &parsed); err == nil {
+			for k := range parsed {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				b.WriteByte(' ')
+				b.WriteString(k)
+				b.WriteByte('=')
+				val, _ := json.Marshal(parsed[k])
+				b.Write(val)
+			}
+		} else {
+			b.Write(r.Args)
+		}
+	}
+	return b.String()
+}
+
+type Embedding struct {
+	Vector []float32
+	Model  string
+}
+
+type Embedder interface {
+	Embed(ctx context.Context, req EmbedRequest) (Embedding, error)
+	Provider() Provider
+	Close() error
+}
+
+type Config struct {
+	Provider Provider      `yaml:"provider"`
+	Ollama   *OllamaConfig `yaml:"ollama,omitempty"`
+	OpenAI   *OpenAIConfig `yaml:"openai,omitempty"`
+}
+
+func (c Config) Validate() error {
+	switch c.Provider {
+	case ProviderOllama:
+		if c.Ollama == nil {
+			return fmt.Errorf("embedder: ollama config required when provider=%q", c.Provider)
+		}
+		return c.Ollama.Validate()
+	case ProviderOpenAI:
+		if c.OpenAI == nil {
+			return fmt.Errorf("embedder: openai config required when provider=%q", c.Provider)
+		}
+		return c.OpenAI.Validate()
+	default:
+		return fmt.Errorf("embedder: unknown provider %q", c.Provider)
+	}
+}

--- a/pkg/cache/embedder/embedder_test.go
+++ b/pkg/cache/embedder/embedder_test.go
@@ -16,11 +16,13 @@ type mockEmbedder struct {
 	err      error
 	provider Provider
 	inputs   []string
+	calls    int
 }
 
 func (m *mockEmbedder) Embed(_ context.Context, req EmbedRequest) (Embedding, error) {
 	m.mu.Lock()
 	m.inputs = append(m.inputs, req.Input())
+	m.calls++
 	m.mu.Unlock()
 	return m.emb, m.err
 }
@@ -76,7 +78,6 @@ func TestEmbedRequestInputOrderDeterministic(t *testing.T) {
 		Args:     json.RawMessage(`{"z":1,"a":2,"m":3}`),
 	}
 	got := req.Input()
-	// Must be sorted: a, m, z
 	if !strings.Contains(got, " a=2") || !strings.Contains(got, " m=3") || !strings.Contains(got, " z=1") {
 		t.Errorf("expected sorted keys, got: %s", got)
 	}
@@ -108,12 +109,26 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "valid ollama config",
-			cfg:  Config{Provider: ProviderOllama, Ollama: &OllamaConfig{URL: "http://localhost:11434"}},
+			cfg:  Config{Provider: ProviderOllama, Ollama: &OllamaConfig{URL: "http://localhost:11434", Model: "m"}},
 		},
 		{
-			name:    "invalid ollama url",
-			cfg:     Config{Provider: ProviderOllama, Ollama: &OllamaConfig{URL: "://invalid"}},
-			wantErr: "invalid url",
+			name: "valid openai config",
+			cfg:  Config{Provider: ProviderOpenAI, OpenAI: &OpenAIConfig{APIKey: "sk-test"}},
+		},
+		{
+			name:    "empty ollama url",
+			cfg:     Config{Provider: ProviderOllama, Ollama: &OllamaConfig{URL: " "}},
+			wantErr: "url must not be empty",
+		},
+		{
+			name:    "bad scheme",
+			cfg:     Config{Provider: ProviderOllama, Ollama: &OllamaConfig{URL: "ftp://x"}},
+			wantErr: "scheme must be http or https",
+		},
+		{
+			name:    "empty model",
+			cfg:     Config{Provider: ProviderOllama, Ollama: &OllamaConfig{URL: "http://localhost:11434", Model: " "}},
+			wantErr: "model must not be empty",
 		},
 	}
 	for _, tc := range tests {
@@ -182,13 +197,10 @@ func TestPoolEmbedError(t *testing.T) {
 func TestPoolFullQueue(t *testing.T) {
 	blocker := &blockingEmbedder{block: make(chan struct{})}
 	pool := NewPool(blocker, PoolConfig{Size: 1, Queue: 1}, nil)
-	defer pool.Close()
 
-	// Fill the pool
 	_, _ = pool.Embed(context.Background(), EmbedRequest{ToolName: "a"})
 	_, _ = pool.Embed(context.Background(), EmbedRequest{ToolName: "b"})
 
-	// Next submit should fail with pool full
 	_, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "c"})
 	select {
 	case err := <-errCh:
@@ -200,6 +212,7 @@ func TestPoolFullQueue(t *testing.T) {
 	}
 
 	close(blocker.block)
+	pool.Close()
 }
 
 type blockingEmbedder struct {
@@ -220,13 +233,24 @@ func TestNewPoolDefaults(t *testing.T) {
 		t.Fatal("expected non-nil pool")
 	}
 	defer pool.Close()
+	if pool.Size() != defaultPoolSize {
+		t.Errorf("default size = %d, want %d", pool.Size(), defaultPoolSize)
+	}
+}
+
+func TestPoolConfigBounds(t *testing.T) {
+	cfg := PoolConfig{Size: 100000, Queue: 10000000}.withDefaults()
+	if cfg.Size > maxPoolSize {
+		t.Errorf("size not capped: %d", cfg.Size)
+	}
+	if cfg.Queue > maxPoolQueue {
+		t.Errorf("queue not capped: %d", cfg.Queue)
+	}
 }
 
 func TestOllamaConfigValidate(t *testing.T) {
 	cfg := &OllamaConfig{}
-	if err := cfg.Validate(); err != nil {
-		t.Errorf("default config should validate: %v", err)
-	}
+	cfg.withDefaults()
 	if cfg.URL != defaultOllamaURL {
 		t.Errorf("default url = %q, want %q", cfg.URL, defaultOllamaURL)
 	}
@@ -235,34 +259,45 @@ func TestOllamaConfigValidate(t *testing.T) {
 	}
 
 	cfg2 := &OllamaConfig{URL: "http://myhost:8080", Model: "my-model"}
-	if err := cfg2.Validate(); err != nil {
-		t.Errorf("valid custom config: %v", err)
+	cfg2.withDefaults()
+	if cfg2.URL != "http://myhost:8080" || cfg2.Model != "my-model" {
+		t.Errorf("custom config not preserved: %+v", cfg2)
 	}
 }
 
-func TestOllamaConfigValidateBadURL(t *testing.T) {
-	cfg := &OllamaConfig{URL: "://bad"}
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "invalid url") {
-		t.Errorf("expected invalid url error, got: %v", err)
+func TestOllamaConfigValidateURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantErr string
+	}{
+		{"", "url must not be empty"},
+		{"  ", "url must not be empty"},
+		{"ftp://x", "scheme must be http or https"},
+		{"://bad", "invalid url"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			err := validateOllamaURL(tt.url)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("url %q: error = %v, want contain %q", tt.url, err, tt.wantErr)
+			}
+		})
 	}
 }
 
 func TestOpenAIConfigValidate(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 
-	// No API key set should fail
 	cfg := &OpenAIConfig{}
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "OPENAI_API_KEY") {
+	if err := cfg.validateKey(); err == nil || !strings.Contains(err.Error(), "OPENAI_API_KEY") {
 		t.Errorf("expected OPENAI_API_KEY error, got: %v", err)
 	}
 
-	// API key in config should pass
 	cfg2 := &OpenAIConfig{APIKey: "sk-test"}
-	if err := cfg2.Validate(); err != nil {
+	if err := cfg2.validateKey(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+	cfg2.withDefaults()
 	if cfg2.Model != defaultOpenAIModel {
 		t.Errorf("default model = %q, want %q", cfg2.Model, defaultOpenAIModel)
 	}
@@ -289,41 +324,130 @@ func TestNewOpenAIEmbedderWithKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if e.cfg.apiKey() != "sk-test" {
-		t.Errorf("apiKey() = %q, want %q", e.cfg.apiKey(), "sk-test")
+	if e.apiKey != "sk-test" {
+		t.Errorf("apiKey = %q, want %q", e.apiKey, "sk-test")
 	}
 	e.Close()
+}
+
+func TestOllamaEmbedPayloadTooLarge(t *testing.T) {
+	e, err := NewOllamaEmbedder(OllamaConfig{URL: "http://localhost:11434"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+
+	big := make([]byte, MaxPayloadBytes+1)
+	for i := range big {
+		big[i] = 'a'
+	}
+	_, err = e.Embed(context.Background(), EmbedRequest{ToolName: "x", Args: big})
+	if !errors.Is(err, ErrPayloadTooLarge) {
+		t.Errorf("expected ErrPayloadTooLarge, got: %v", err)
+	}
 }
 
 func TestPoolConcurrentEmbed(t *testing.T) {
 	mock := &mockEmbedder{
 		emb: Embedding{Vector: []float32{0.5}, Model: "test"},
 	}
-	pool := NewPool(mock, PoolConfig{Size: 4, Queue: 100}, nil)
+	pool := NewPool(mock, PoolConfig{Size: 4, Queue: 200}, nil)
 	defer pool.Close()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	errCount := 0
+	var errMu sync.Mutex
+	for i := 0; i < 50; i++ {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
 			resultCh, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "tool"})
 			select {
-			case <-resultCh:
-			case <-errCh:
-				t.Errorf("goroutine %d got error", n)
-			case <-time.After(time.Second):
-				t.Errorf("goroutine %d timeout", n)
+			case _, ok := <-resultCh:
+				if !ok {
+					errMu.Lock()
+					errCount++
+					errMu.Unlock()
+				}
+			case _, ok := <-errCh:
+				if ok {
+					errMu.Lock()
+					errCount++
+					errMu.Unlock()
+				}
+			case <-time.After(2 * time.Second):
+				errMu.Lock()
+				errCount++
+				errMu.Unlock()
 			}
 		}(i)
 	}
 	wg.Wait()
+	if errCount > 0 {
+		t.Errorf("%d goroutines got errors", errCount)
+	}
 }
 
-func TestNewPoolClose(t *testing.T) {
+func TestPoolDoubleClose(t *testing.T) {
 	mock := &mockEmbedder{emb: Embedding{Vector: []float32{0.1}, Model: "t"}}
 	pool := NewPool(mock, PoolConfig{Size: 2}, nil)
 	pool.Close()
-	// Close twice should not panic
+	// Second close should not panic
 	pool.Close()
+}
+
+func TestEmbedderUnavailableWrapped(t *testing.T) {
+	e, err := NewOllamaEmbedder(OllamaConfig{URL: "http://localhost:11434"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+	if !errors.Is(embedderSentinel(), ErrEmbedderUnavailable) {
+		t.Error("ErrEmbedderUnavailable should be a sentinel")
+	}
+}
+
+func embedderSentinel() error { return ErrEmbedderUnavailable }
+
+// Benchmark: NFR11 <5ms p95 (NFR11: hot-path overhead target).
+// Measures the cost of building the embed input string (the only sync work
+// done on the request hot path before submitting to the async pool).
+func BenchmarkEmbedRequestInput(b *testing.B) {
+	args := json.RawMessage(`{"location":"San Francisco","unit":"celsius","date":"2026-06-27","hourly":true}`)
+	req := EmbedRequest{ToolName: "get_weather", Args: args}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = req.Input()
+	}
+}
+
+// Benchmark the async pool submit path (the actual hot-path call site).
+// This is the overhead added per outbound tool call when embedder is enabled.
+func BenchmarkPoolSubmit(b *testing.B) {
+	mock := &mockEmbedder{emb: Embedding{Vector: make([]float32, 384), Model: "m"}}
+	pool := NewPool(mock, PoolConfig{Size: 8, Queue: 1024}, nil)
+	defer pool.Close()
+
+	args := json.RawMessage(`{"location":"San Francisco","unit":"celsius"}`)
+	req := EmbedRequest{ToolName: "get_weather", Args: args}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resultCh, errCh := pool.Embed(context.Background(), req)
+		// Drain to avoid leaking goroutines
+		select {
+		case <-resultCh:
+		case <-errCh:
+		}
+	}
+}
+
+// Benchmark input formatting with a large payload (max-allowed size).
+func BenchmarkEmbedRequestInputLarge(b *testing.B) {
+	bigArgs := json.RawMessage(`"` + strings.Repeat("x", MaxPayloadBytes-2) + `"`)
+	req := EmbedRequest{ToolName: "big_tool", Args: bigArgs}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = req.Input()
+	}
 }

--- a/pkg/cache/embedder/embedder_test.go
+++ b/pkg/cache/embedder/embedder_test.go
@@ -158,18 +158,19 @@ func TestPoolEmbed(t *testing.T) {
 	pool := NewPool(mock, PoolConfig{Size: 2}, nil)
 	defer pool.Close()
 
-	resultCh, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "test"})
+	outCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "test"})
 
 	select {
-	case emb := <-resultCh:
-		if len(emb.Vector) != 3 {
-			t.Errorf("expected 3 dims, got %d", len(emb.Vector))
+	case o := <-outCh:
+		if o.Err != nil {
+			t.Fatalf("unexpected error: %v", o.Err)
 		}
-		if emb.Model != "test" {
-			t.Errorf("model = %q, want %q", emb.Model, "test")
+		if len(o.Embedding.Vector) != 3 {
+			t.Errorf("expected 3 dims, got %d", len(o.Embedding.Vector))
 		}
-	case err := <-errCh:
-		t.Fatalf("unexpected error: %v", err)
+		if o.Embedding.Model != "test" {
+			t.Errorf("model = %q, want %q", o.Embedding.Model, "test")
+		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for embed result")
 	}
@@ -182,12 +183,12 @@ func TestPoolEmbedError(t *testing.T) {
 	pool := NewPool(mock, PoolConfig{Size: 1}, nil)
 	defer pool.Close()
 
-	_, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "test"})
+	outCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "test"})
 
 	select {
-	case err := <-errCh:
-		if err == nil || !strings.Contains(err.Error(), "embed failed") {
-			t.Errorf("expected 'embed failed', got: %v", err)
+	case o := <-outCh:
+		if o.Err == nil || !strings.Contains(o.Err.Error(), "embed failed") {
+			t.Errorf("expected 'embed failed', got: %v", o.Err)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for error")
@@ -198,17 +199,31 @@ func TestPoolFullQueue(t *testing.T) {
 	blocker := &blockingEmbedder{block: make(chan struct{})}
 	pool := NewPool(blocker, PoolConfig{Size: 1, Queue: 1}, nil)
 
-	_, _ = pool.Embed(context.Background(), EmbedRequest{ToolName: "a"})
-	_, _ = pool.Embed(context.Background(), EmbedRequest{ToolName: "b"})
+	// Fill both slots: one in worker, one in queue.
+	if ch := pool.Embed(context.Background(), EmbedRequest{ToolName: "a"}); ch == nil {
+		t.Fatal("nil channel for a")
+	}
+	// Give the worker a moment to actually pick up "a" and enter blocker.Embed.
+	// Without this sleep, the race detector can schedule j2 into the queue
+	// before j1 has reached the blocking call, leaving a queue slot for j3.
+	time.Sleep(2 * time.Millisecond)
+	if ch := pool.Embed(context.Background(), EmbedRequest{ToolName: "b"}); ch == nil {
+		t.Fatal("nil channel for b")
+	}
 
-	_, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "c"})
+	// Third call should hit the pool-full path.
+	outCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "c"})
+	if outCh == nil {
+		t.Fatal("nil channel for c")
+	}
+
 	select {
-	case err := <-errCh:
-		if !errors.Is(err, ErrPoolFull) {
-			t.Errorf("expected ErrPoolFull, got: %v", err)
+	case o, ok := <-outCh:
+		if !errors.Is(o.Err, ErrPoolFull) {
+			t.Errorf("expected ErrPoolFull, got: %v (ok=%v)", o.Err, ok)
 		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for pool-full outcome")
 	}
 
 	close(blocker.block)
@@ -220,8 +235,12 @@ type blockingEmbedder struct {
 }
 
 func (b *blockingEmbedder) Embed(ctx context.Context, _ EmbedRequest) (Embedding, error) {
-	<-b.block
-	return Embedding{}, nil
+	select {
+	case <-b.block:
+		return Embedding{}, nil
+	case <-ctx.Done():
+		return Embedding{}, ctx.Err()
+	}
 }
 func (b *blockingEmbedder) Provider() Provider { return ProviderOllama }
 func (b *blockingEmbedder) Close() error       { return nil }
@@ -361,16 +380,10 @@ func TestPoolConcurrentEmbed(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			resultCh, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "tool"})
+			outCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "tool"})
 			select {
-			case _, ok := <-resultCh:
-				if !ok {
-					errMu.Lock()
-					errCount++
-					errMu.Unlock()
-				}
-			case _, ok := <-errCh:
-				if ok {
+			case o, ok := <-outCh:
+				if !ok || o.Err != nil {
 					errMu.Lock()
 					errCount++
 					errMu.Unlock()
@@ -394,6 +407,42 @@ func TestPoolDoubleClose(t *testing.T) {
 	pool.Close()
 	// Second close should not panic
 	pool.Close()
+}
+
+// TestPoolCloseCancelsInFlight verifies the deferred fix: workers blocked
+// inside in-flight HTTP calls observe ctx.Done() when Close() is invoked and
+// exit promptly instead of waiting for the HTTP timeout (5–10s).
+func TestPoolCloseCancelsInFlight(t *testing.T) {
+	blocker := &blockingEmbedder{block: make(chan struct{})}
+	pool := NewPool(blocker, PoolConfig{Size: 1}, nil)
+
+	// Submit a job; worker picks it up and blocks inside Embed().
+	outCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "slow"})
+
+	// Give the worker a moment to start the HTTP call.
+	time.Sleep(50 * time.Millisecond)
+
+	// Close should cancel the in-flight call within the HTTP timeout window.
+	closeStart := time.Now()
+	pool.Close()
+	closeDur := time.Since(closeStart)
+
+	if closeDur > 2*time.Second {
+		t.Errorf("Close() took %s, expected < 2s (in-flight should be canceled)", closeDur)
+	}
+
+	// Drain whatever came back. Either way the test must not hang.
+	select {
+	case o, ok := <-outCh:
+		if !ok {
+			t.Error("channel should have delivered an outcome")
+		}
+		if o.Err == nil {
+			t.Error("expected ctx.Canceled error, got nil")
+		}
+	case <-time.After(time.Second):
+		t.Error("channel should have been closed/canceled by now")
+	}
 }
 
 func TestEmbedderUnavailableWrapped(t *testing.T) {
@@ -433,12 +482,9 @@ func BenchmarkPoolSubmit(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		resultCh, errCh := pool.Embed(context.Background(), req)
+		outCh := pool.Embed(context.Background(), req)
 		// Drain to avoid leaking goroutines
-		select {
-		case <-resultCh:
-		case <-errCh:
-		}
+		<-outCh
 	}
 }
 

--- a/pkg/cache/embedder/embedder_test.go
+++ b/pkg/cache/embedder/embedder_test.go
@@ -1,0 +1,329 @@
+package embedder
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type mockEmbedder struct {
+	mu       sync.Mutex
+	emb      Embedding
+	err      error
+	provider Provider
+	inputs   []string
+}
+
+func (m *mockEmbedder) Embed(_ context.Context, req EmbedRequest) (Embedding, error) {
+	m.mu.Lock()
+	m.inputs = append(m.inputs, req.Input())
+	m.mu.Unlock()
+	return m.emb, m.err
+}
+
+func (m *mockEmbedder) Provider() Provider { return m.provider }
+func (m *mockEmbedder) Close() error       { return nil }
+
+func TestEmbedRequestInput(t *testing.T) {
+	tests := []struct {
+		name string
+		req  EmbedRequest
+		want string
+	}{
+		{
+			name: "tool name only",
+			req:  EmbedRequest{ToolName: "get_weather"},
+			want: "get_weather:",
+		},
+		{
+			name: "tool name with args",
+			req:  EmbedRequest{ToolName: "get_weather", Args: json.RawMessage(`{"location":"London","unit":"celsius"}`)},
+			want: "get_weather: location=\"London\" unit=\"celsius\"",
+		},
+		{
+			name: "tool name with single arg",
+			req:  EmbedRequest{ToolName: "search", Args: json.RawMessage(`{"q":"hello"}`)},
+			want: "search: q=\"hello\"",
+		},
+		{
+			name: "invalid json args",
+			req:  EmbedRequest{ToolName: "test", Args: json.RawMessage(`not json`)},
+			want: "test:not json",
+		},
+		{
+			name: "empty args",
+			req:  EmbedRequest{ToolName: "ping", Args: json.RawMessage(`{}`)},
+			want: "ping:",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.req.Input()
+			if got != tc.want {
+				t.Errorf("Input() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEmbedRequestInputOrderDeterministic(t *testing.T) {
+	req := EmbedRequest{
+		ToolName: "test",
+		Args:     json.RawMessage(`{"z":1,"a":2,"m":3}`),
+	}
+	got := req.Input()
+	// Must be sorted: a, m, z
+	if !strings.Contains(got, " a=2") || !strings.Contains(got, " m=3") || !strings.Contains(got, " z=1") {
+		t.Errorf("expected sorted keys, got: %s", got)
+	}
+	if !strings.HasPrefix(got, "test:") {
+		t.Errorf("expected tool: prefix, got: %s", got)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name:    "unknown provider",
+			cfg:     Config{Provider: "unknown"},
+			wantErr: `unknown provider "unknown"`,
+		},
+		{
+			name:    "ollama missing config",
+			cfg:     Config{Provider: ProviderOllama},
+			wantErr: "ollama config required",
+		},
+		{
+			name:    "openai missing config",
+			cfg:     Config{Provider: ProviderOpenAI},
+			wantErr: "openai config required",
+		},
+		{
+			name: "valid ollama config",
+			cfg:  Config{Provider: ProviderOllama, Ollama: &OllamaConfig{URL: "http://localhost:11434"}},
+		},
+		{
+			name:    "invalid ollama url",
+			cfg:     Config{Provider: ProviderOllama, Ollama: &OllamaConfig{URL: "://invalid"}},
+			wantErr: "invalid url",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error containing %q, got nil", tc.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestPoolEmbed(t *testing.T) {
+	mock := &mockEmbedder{
+		emb: Embedding{Vector: []float32{0.1, 0.2, 0.3}, Model: "test"},
+	}
+	pool := NewPool(mock, PoolConfig{Size: 2}, nil)
+	defer pool.Close()
+
+	resultCh, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "test"})
+
+	select {
+	case emb := <-resultCh:
+		if len(emb.Vector) != 3 {
+			t.Errorf("expected 3 dims, got %d", len(emb.Vector))
+		}
+		if emb.Model != "test" {
+			t.Errorf("model = %q, want %q", emb.Model, "test")
+		}
+	case err := <-errCh:
+		t.Fatalf("unexpected error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for embed result")
+	}
+}
+
+func TestPoolEmbedError(t *testing.T) {
+	mock := &mockEmbedder{
+		err: errors.New("embed failed"),
+	}
+	pool := NewPool(mock, PoolConfig{Size: 1}, nil)
+	defer pool.Close()
+
+	_, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "test"})
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "embed failed") {
+			t.Errorf("expected 'embed failed', got: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for error")
+	}
+}
+
+func TestPoolFullQueue(t *testing.T) {
+	blocker := &blockingEmbedder{block: make(chan struct{})}
+	pool := NewPool(blocker, PoolConfig{Size: 1, Queue: 1}, nil)
+	defer pool.Close()
+
+	// Fill the pool
+	_, _ = pool.Embed(context.Background(), EmbedRequest{ToolName: "a"})
+	_, _ = pool.Embed(context.Background(), EmbedRequest{ToolName: "b"})
+
+	// Next submit should fail with pool full
+	_, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "c"})
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrPoolFull) {
+			t.Errorf("expected ErrPoolFull, got: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	close(blocker.block)
+}
+
+type blockingEmbedder struct {
+	block chan struct{}
+}
+
+func (b *blockingEmbedder) Embed(ctx context.Context, _ EmbedRequest) (Embedding, error) {
+	<-b.block
+	return Embedding{}, nil
+}
+func (b *blockingEmbedder) Provider() Provider { return ProviderOllama }
+func (b *blockingEmbedder) Close() error       { return nil }
+
+func TestNewPoolDefaults(t *testing.T) {
+	mock := &mockEmbedder{}
+	pool := NewPool(mock, PoolConfig{}, nil)
+	if pool == nil {
+		t.Fatal("expected non-nil pool")
+	}
+	defer pool.Close()
+}
+
+func TestOllamaConfigValidate(t *testing.T) {
+	cfg := &OllamaConfig{}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("default config should validate: %v", err)
+	}
+	if cfg.URL != defaultOllamaURL {
+		t.Errorf("default url = %q, want %q", cfg.URL, defaultOllamaURL)
+	}
+	if cfg.Model != defaultOllamaModel {
+		t.Errorf("default model = %q, want %q", cfg.Model, defaultOllamaModel)
+	}
+
+	cfg2 := &OllamaConfig{URL: "http://myhost:8080", Model: "my-model"}
+	if err := cfg2.Validate(); err != nil {
+		t.Errorf("valid custom config: %v", err)
+	}
+}
+
+func TestOllamaConfigValidateBadURL(t *testing.T) {
+	cfg := &OllamaConfig{URL: "://bad"}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "invalid url") {
+		t.Errorf("expected invalid url error, got: %v", err)
+	}
+}
+
+func TestOpenAIConfigValidate(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+
+	// No API key set should fail
+	cfg := &OpenAIConfig{}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "OPENAI_API_KEY") {
+		t.Errorf("expected OPENAI_API_KEY error, got: %v", err)
+	}
+
+	// API key in config should pass
+	cfg2 := &OpenAIConfig{APIKey: "sk-test"}
+	if err := cfg2.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if cfg2.Model != defaultOpenAIModel {
+		t.Errorf("default model = %q, want %q", cfg2.Model, defaultOpenAIModel)
+	}
+}
+
+func TestNewOllamaEmbedderBadURL(t *testing.T) {
+	_, err := NewOllamaEmbedder(OllamaConfig{URL: "://bad"}, nil)
+	if err == nil {
+		t.Error("expected error for bad URL")
+	}
+}
+
+func TestNewOpenAIEmbedderNoKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+
+	_, err := NewOpenAIEmbedder(OpenAIConfig{}, nil)
+	if err == nil {
+		t.Error("expected error for missing API key")
+	}
+}
+
+func TestNewOpenAIEmbedderWithKey(t *testing.T) {
+	e, err := NewOpenAIEmbedder(OpenAIConfig{APIKey: "sk-test"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e.cfg.apiKey() != "sk-test" {
+		t.Errorf("apiKey() = %q, want %q", e.cfg.apiKey(), "sk-test")
+	}
+	e.Close()
+}
+
+func TestPoolConcurrentEmbed(t *testing.T) {
+	mock := &mockEmbedder{
+		emb: Embedding{Vector: []float32{0.5}, Model: "test"},
+	}
+	pool := NewPool(mock, PoolConfig{Size: 4, Queue: 100}, nil)
+	defer pool.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			resultCh, errCh := pool.Embed(context.Background(), EmbedRequest{ToolName: "tool"})
+			select {
+			case <-resultCh:
+			case <-errCh:
+				t.Errorf("goroutine %d got error", n)
+			case <-time.After(time.Second):
+				t.Errorf("goroutine %d timeout", n)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestNewPoolClose(t *testing.T) {
+	mock := &mockEmbedder{emb: Embedding{Vector: []float32{0.1}, Model: "t"}}
+	pool := NewPool(mock, PoolConfig{Size: 2}, nil)
+	pool.Close()
+	// Close twice should not panic
+	pool.Close()
+}

--- a/pkg/cache/embedder/ollama.go
+++ b/pkg/cache/embedder/ollama.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"strings"
 	"time"
 )
 
@@ -24,15 +28,30 @@ type OllamaConfig struct {
 	Model string `yaml:"model"`
 }
 
-func (c *OllamaConfig) Validate() error {
+func (c *OllamaConfig) withDefaults() {
 	if c.URL == "" {
 		c.URL = defaultOllamaURL
 	}
-	if _, err := url.Parse(c.URL); err != nil {
-		return fmt.Errorf("embedder ollama: invalid url %q: %w", c.URL, err)
-	}
 	if c.Model == "" {
 		c.Model = defaultOllamaModel
+	}
+}
+
+func validateOllamaURL(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("url must not be empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid url %q: %w", raw, err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("scheme must be http or https, got %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("url must include a host")
 	}
 	return nil
 }
@@ -54,8 +73,9 @@ type OllamaEmbedder struct {
 }
 
 func NewOllamaEmbedder(cfg OllamaConfig, logger *slog.Logger) (*OllamaEmbedder, error) {
-	if err := cfg.Validate(); err != nil {
-		return nil, err
+	cfg.withDefaults()
+	if err := validateOllamaURL(cfg.URL); err != nil {
+		return nil, fmt.Errorf("embedder ollama: %w", err)
 	}
 	if logger == nil {
 		logger = slog.Default()
@@ -75,6 +95,9 @@ func NewOllamaEmbedder(cfg OllamaConfig, logger *slog.Logger) (*OllamaEmbedder, 
 
 func (e *OllamaEmbedder) Embed(ctx context.Context, req EmbedRequest) (Embedding, error) {
 	input := req.Input()
+	if len(input) > MaxPayloadBytes {
+		return Embedding{}, fmt.Errorf("%w: %d > %d", ErrPayloadTooLarge, len(input), MaxPayloadBytes)
+	}
 	e.logger.Debug("ollama embed", "tool", req.ToolName, "input_length", len(input))
 
 	body := ollamaEmbedRequest{
@@ -87,7 +110,10 @@ func (e *OllamaEmbedder) Embed(ctx context.Context, req EmbedRequest) (Embedding
 		return Embedding{}, fmt.Errorf("ollama embed marshal: %w", err)
 	}
 
-	u, _ := url.JoinPath(e.cfg.URL, ollamaEmbedPath)
+	u, err := url.JoinPath(e.cfg.URL, ollamaEmbedPath)
+	if err != nil {
+		return Embedding{}, fmt.Errorf("ollama embed join path: %w", err)
+	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(payload))
 	if err != nil {
 		return Embedding{}, fmt.Errorf("ollama embed request: %w", err)
@@ -96,12 +122,15 @@ func (e *OllamaEmbedder) Embed(ctx context.Context, req EmbedRequest) (Embedding
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
+		if isHostUnreachable(err) {
+			return Embedding{}, fmt.Errorf("%w: %v", ErrEmbedderUnavailable, err)
+		}
 		return Embedding{}, fmt.Errorf("ollama embed call: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		return Embedding{}, fmt.Errorf("ollama embed: status %d: %s", resp.StatusCode, string(respBody))
 	}
 
@@ -110,8 +139,8 @@ func (e *OllamaEmbedder) Embed(ctx context.Context, req EmbedRequest) (Embedding
 		return Embedding{}, fmt.Errorf("ollama embed decode: %w", err)
 	}
 
-	if len(embedResp.Embeddings) == 0 {
-		return Embedding{}, fmt.Errorf("ollama embed: empty embeddings response")
+	if len(embedResp.Embeddings) == 0 || len(embedResp.Embeddings[0]) == 0 {
+		return Embedding{}, errors.New("ollama embed: empty vector in response")
 	}
 
 	return Embedding{
@@ -126,5 +155,50 @@ func (e *OllamaEmbedder) Provider() Provider {
 
 func (e *OllamaEmbedder) Close() error {
 	e.client.CloseIdleConnections()
+	return nil
+}
+
+func isHostUnreachable(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	if strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "no such host") ||
+		strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "i/o timeout") {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return false
+}
+
+// IsAPIAvailable probes the Ollama server with a GET on the root URL.
+// Returns nil if reachable, an error otherwise. Used by startup checks.
+func IsAPIAvailable(ctx context.Context, baseURL string) error {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("ollama probe: %w", err)
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("ollama probe: %w", err)
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("ollama probe: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("ollama probe: status %d", resp.StatusCode)
+	}
+	_ = os.Getenv("") // keep os import for future probe extension
 	return nil
 }

--- a/pkg/cache/embedder/ollama.go
+++ b/pkg/cache/embedder/ollama.go
@@ -1,0 +1,130 @@
+package embedder
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	defaultOllamaURL   = "http://localhost:11434"
+	defaultOllamaModel = "nomic-embed-text"
+	ollamaEmbedPath    = "/api/embed"
+	ollamaTimeout      = 5 * time.Second
+)
+
+type OllamaConfig struct {
+	URL   string `yaml:"url"`
+	Model string `yaml:"model"`
+}
+
+func (c *OllamaConfig) Validate() error {
+	if c.URL == "" {
+		c.URL = defaultOllamaURL
+	}
+	if _, err := url.Parse(c.URL); err != nil {
+		return fmt.Errorf("embedder ollama: invalid url %q: %w", c.URL, err)
+	}
+	if c.Model == "" {
+		c.Model = defaultOllamaModel
+	}
+	return nil
+}
+
+type ollamaEmbedRequest struct {
+	Model    string   `json:"model"`
+	Input    []string `json:"input"`
+	Truncate bool     `json:"truncate"`
+}
+
+type ollamaEmbedResponse struct {
+	Embeddings [][]float32 `json:"embeddings"`
+}
+
+type OllamaEmbedder struct {
+	cfg    OllamaConfig
+	client *http.Client
+	logger *slog.Logger
+}
+
+func NewOllamaEmbedder(cfg OllamaConfig, logger *slog.Logger) (*OllamaEmbedder, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OllamaEmbedder{
+		cfg: cfg,
+		client: &http.Client{
+			Timeout: ollamaTimeout,
+			Transport: &http.Transport{
+				MaxIdleConns:    10,
+				IdleConnTimeout: 30 * time.Second,
+			},
+		},
+		logger: logger,
+	}, nil
+}
+
+func (e *OllamaEmbedder) Embed(ctx context.Context, req EmbedRequest) (Embedding, error) {
+	input := req.Input()
+	e.logger.Debug("ollama embed", "tool", req.ToolName, "input_length", len(input))
+
+	body := ollamaEmbedRequest{
+		Model:    e.cfg.Model,
+		Input:    []string{input},
+		Truncate: true,
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return Embedding{}, fmt.Errorf("ollama embed marshal: %w", err)
+	}
+
+	u, _ := url.JoinPath(e.cfg.URL, ollamaEmbedPath)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(payload))
+	if err != nil {
+		return Embedding{}, fmt.Errorf("ollama embed request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(httpReq)
+	if err != nil {
+		return Embedding{}, fmt.Errorf("ollama embed call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return Embedding{}, fmt.Errorf("ollama embed: status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var embedResp ollamaEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
+		return Embedding{}, fmt.Errorf("ollama embed decode: %w", err)
+	}
+
+	if len(embedResp.Embeddings) == 0 {
+		return Embedding{}, fmt.Errorf("ollama embed: empty embeddings response")
+	}
+
+	return Embedding{
+		Vector: embedResp.Embeddings[0],
+		Model:  e.cfg.Model,
+	}, nil
+}
+
+func (e *OllamaEmbedder) Provider() Provider {
+	return ProviderOllama
+}
+
+func (e *OllamaEmbedder) Close() error {
+	e.client.CloseIdleConnections()
+	return nil
+}

--- a/pkg/cache/embedder/openai.go
+++ b/pkg/cache/embedder/openai.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	// #nosec G101 -- this is the env var NAME, not a credential
 	envOpenAIAPIKey    = "OPENAI_API_KEY"
 	defaultOpenAIModel = "text-embedding-3-small"
 	openAIEmbedURL     = "https://api.openai.com/v1/embeddings"

--- a/pkg/cache/embedder/openai.go
+++ b/pkg/cache/embedder/openai.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -17,6 +19,7 @@ const (
 	defaultOpenAIModel = "text-embedding-3-small"
 	openAIEmbedURL     = "https://api.openai.com/v1/embeddings"
 	openAITimeout      = 10 * time.Second
+	maxErrorBodyBytes  = 4 * 1024
 )
 
 type OpenAIConfig struct {
@@ -24,13 +27,16 @@ type OpenAIConfig struct {
 	APIKey string `yaml:"api_key,omitempty"`
 }
 
-func (c *OpenAIConfig) Validate() error {
+func (c *OpenAIConfig) withDefaults() {
 	if c.Model == "" {
 		c.Model = defaultOpenAIModel
 	}
-	key := c.APIKey
+}
+
+func (c *OpenAIConfig) validateKey() error {
+	key := strings.TrimSpace(c.APIKey)
 	if key == "" {
-		key = os.Getenv(envOpenAIAPIKey)
+		key = strings.TrimSpace(os.Getenv(envOpenAIAPIKey))
 	}
 	if key == "" {
 		return fmt.Errorf("embedder openai: %s env var not set and no api_key in config", envOpenAIAPIKey)
@@ -38,11 +44,12 @@ func (c *OpenAIConfig) Validate() error {
 	return nil
 }
 
-func (c *OpenAIConfig) apiKey() string {
-	if c.APIKey != "" {
-		return c.APIKey
+func (c *OpenAIConfig) resolvedAPIKey() string {
+	key := strings.TrimSpace(c.APIKey)
+	if key != "" {
+		return key
 	}
-	return os.Getenv(envOpenAIAPIKey)
+	return strings.TrimSpace(os.Getenv(envOpenAIAPIKey))
 }
 
 type openAIEmbedRequest struct {
@@ -61,19 +68,26 @@ type openAIEmbedData struct {
 
 type OpenAIEmbedder struct {
 	cfg    OpenAIConfig
+	apiKey string
 	client *http.Client
 	logger *slog.Logger
 }
 
 func NewOpenAIEmbedder(cfg OpenAIConfig, logger *slog.Logger) (*OpenAIEmbedder, error) {
-	if err := cfg.Validate(); err != nil {
+	cfg.withDefaults()
+	if err := cfg.validateKey(); err != nil {
 		return nil, err
 	}
 	if logger == nil {
 		logger = slog.Default()
 	}
+	key := cfg.resolvedAPIKey()
+	if key == "" {
+		return nil, errors.New("embedder openai: resolved api key is empty")
+	}
 	return &OpenAIEmbedder{
-		cfg: cfg,
+		cfg:    cfg,
+		apiKey: key,
 		client: &http.Client{
 			Timeout: openAITimeout,
 			Transport: &http.Transport{
@@ -87,6 +101,9 @@ func NewOpenAIEmbedder(cfg OpenAIConfig, logger *slog.Logger) (*OpenAIEmbedder, 
 
 func (e *OpenAIEmbedder) Embed(ctx context.Context, req EmbedRequest) (Embedding, error) {
 	input := req.Input()
+	if len(input) > MaxPayloadBytes {
+		return Embedding{}, fmt.Errorf("%w: %d > %d", ErrPayloadTooLarge, len(input), MaxPayloadBytes)
+	}
 
 	body := openAIEmbedRequest{
 		Model: e.cfg.Model,
@@ -102,16 +119,16 @@ func (e *OpenAIEmbedder) Embed(ctx context.Context, req EmbedRequest) (Embedding
 		return Embedding{}, fmt.Errorf("openai embed request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+e.cfg.apiKey())
+	httpReq.Header.Set("Authorization", "Bearer "+e.apiKey)
 
 	resp, err := e.client.Do(httpReq)
 	if err != nil {
-		return Embedding{}, fmt.Errorf("openai embed call: %w", err)
+		return Embedding{}, fmt.Errorf("%w: %v", ErrEmbedderUnavailable, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		return Embedding{}, fmt.Errorf("openai embed: status %d: %s", resp.StatusCode, string(respBody))
 	}
 
@@ -120,8 +137,8 @@ func (e *OpenAIEmbedder) Embed(ctx context.Context, req EmbedRequest) (Embedding
 		return Embedding{}, fmt.Errorf("openai embed decode: %w", err)
 	}
 
-	if len(embedResp.Data) == 0 {
-		return Embedding{}, fmt.Errorf("openai embed: empty data response")
+	if len(embedResp.Data) == 0 || len(embedResp.Data[0].Vector) == 0 {
+		return Embedding{}, errors.New("openai embed: empty vector in response")
 	}
 
 	return Embedding{

--- a/pkg/cache/embedder/openai.go
+++ b/pkg/cache/embedder/openai.go
@@ -1,0 +1,140 @@
+package embedder
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	envOpenAIAPIKey    = "OPENAI_API_KEY"
+	defaultOpenAIModel = "text-embedding-3-small"
+	openAIEmbedURL     = "https://api.openai.com/v1/embeddings"
+	openAITimeout      = 10 * time.Second
+)
+
+type OpenAIConfig struct {
+	Model  string `yaml:"model"`
+	APIKey string `yaml:"api_key,omitempty"`
+}
+
+func (c *OpenAIConfig) Validate() error {
+	if c.Model == "" {
+		c.Model = defaultOpenAIModel
+	}
+	key := c.APIKey
+	if key == "" {
+		key = os.Getenv(envOpenAIAPIKey)
+	}
+	if key == "" {
+		return fmt.Errorf("embedder openai: %s env var not set and no api_key in config", envOpenAIAPIKey)
+	}
+	return nil
+}
+
+func (c *OpenAIConfig) apiKey() string {
+	if c.APIKey != "" {
+		return c.APIKey
+	}
+	return os.Getenv(envOpenAIAPIKey)
+}
+
+type openAIEmbedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type openAIEmbedResponse struct {
+	Data []openAIEmbedData `json:"data"`
+}
+
+type openAIEmbedData struct {
+	Index  int       `json:"index"`
+	Vector []float32 `json:"embedding"`
+}
+
+type OpenAIEmbedder struct {
+	cfg    OpenAIConfig
+	client *http.Client
+	logger *slog.Logger
+}
+
+func NewOpenAIEmbedder(cfg OpenAIConfig, logger *slog.Logger) (*OpenAIEmbedder, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OpenAIEmbedder{
+		cfg: cfg,
+		client: &http.Client{
+			Timeout: openAITimeout,
+			Transport: &http.Transport{
+				MaxIdleConns:    10,
+				IdleConnTimeout: 30 * time.Second,
+			},
+		},
+		logger: logger,
+	}, nil
+}
+
+func (e *OpenAIEmbedder) Embed(ctx context.Context, req EmbedRequest) (Embedding, error) {
+	input := req.Input()
+
+	body := openAIEmbedRequest{
+		Model: e.cfg.Model,
+		Input: []string{input},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return Embedding{}, fmt.Errorf("openai embed marshal: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIEmbedURL, bytes.NewReader(payload))
+	if err != nil {
+		return Embedding{}, fmt.Errorf("openai embed request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+e.cfg.apiKey())
+
+	resp, err := e.client.Do(httpReq)
+	if err != nil {
+		return Embedding{}, fmt.Errorf("openai embed call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return Embedding{}, fmt.Errorf("openai embed: status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var embedResp openAIEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
+		return Embedding{}, fmt.Errorf("openai embed decode: %w", err)
+	}
+
+	if len(embedResp.Data) == 0 {
+		return Embedding{}, fmt.Errorf("openai embed: empty data response")
+	}
+
+	return Embedding{
+		Vector: embedResp.Data[0].Vector,
+		Model:  e.cfg.Model,
+	}, nil
+}
+
+func (e *OpenAIEmbedder) Provider() Provider {
+	return ProviderOpenAI
+}
+
+func (e *OpenAIEmbedder) Close() error {
+	e.client.CloseIdleConnections()
+	return nil
+}

--- a/pkg/cache/embedder/pool.go
+++ b/pkg/cache/embedder/pool.go
@@ -9,11 +9,29 @@ import (
 const (
 	defaultPoolSize  = 4
 	defaultPoolQueue = 256
+	maxPoolSize      = 256
+	maxPoolQueue     = 4096
 )
 
 type PoolConfig struct {
 	Size  int `yaml:"size"`
 	Queue int `yaml:"queue"`
+}
+
+func (p PoolConfig) withDefaults() PoolConfig {
+	if p.Size <= 0 {
+		p.Size = defaultPoolSize
+	}
+	if p.Queue <= 0 {
+		p.Queue = defaultPoolQueue
+	}
+	if p.Size > maxPoolSize {
+		p.Size = maxPoolSize
+	}
+	if p.Queue > maxPoolQueue {
+		p.Queue = maxPoolQueue
+	}
+	return p
 }
 
 type job struct {
@@ -24,20 +42,17 @@ type job struct {
 }
 
 type Pool struct {
-	embedder Embedder
-	jobs     chan job
-	wg       sync.WaitGroup
-	quit     chan struct{}
-	logger   *slog.Logger
+	embedder  Embedder
+	jobs      chan job
+	wg        sync.WaitGroup
+	quit      chan struct{}
+	closeOnce sync.Once
+	logger    *slog.Logger
+	size      int
 }
 
 func NewPool(embedder Embedder, cfg PoolConfig, logger *slog.Logger) *Pool {
-	if cfg.Size <= 0 {
-		cfg.Size = defaultPoolSize
-	}
-	if cfg.Queue <= 0 {
-		cfg.Queue = defaultPoolQueue
-	}
+	cfg = cfg.withDefaults()
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -47,6 +62,7 @@ func NewPool(embedder Embedder, cfg PoolConfig, logger *slog.Logger) *Pool {
 		jobs:     make(chan job, cfg.Queue),
 		quit:     make(chan struct{}),
 		logger:   logger,
+		size:     cfg.Size,
 	}
 
 	for i := 0; i < cfg.Size; i++ {
@@ -63,12 +79,20 @@ func (p *Pool) worker(id int) {
 	for {
 		select {
 		case j := <-p.jobs:
+			if err := j.ctx.Err(); err != nil {
+				j.err <- err
+				close(j.result)
+				close(j.err)
+				continue
+			}
 			emb, err := p.embedder.Embed(j.ctx, j.req)
 			if err != nil {
 				j.err <- err
 			} else {
 				j.result <- emb
 			}
+			close(j.result)
+			close(j.err)
 		case <-p.quit:
 			p.logger.Debug("embedder pool worker stopped", "worker_id", id)
 			return
@@ -85,15 +109,13 @@ func (p *Pool) Embed(ctx context.Context, req EmbedRequest) (<-chan Embedding, <
 	}
 	select {
 	case p.jobs <- j:
+		return j.result, j.err
 	default:
-		err := make(chan error, 1)
-		err <- ErrPoolFull
-		close(err)
-		result := make(chan Embedding, 1)
-		close(result)
-		return result, err
+		j.err <- ErrPoolFull
+		close(j.result)
+		close(j.err)
+		return j.result, j.err
 	}
-	return j.result, j.err
 }
 
 var ErrPoolFull = &poolFullError{}
@@ -108,13 +130,14 @@ func (e *poolFullError) Unwrap() error {
 	return nil
 }
 
+func (p *Pool) Size() int {
+	return p.size
+}
+
 func (p *Pool) Close() error {
-	select {
-	case <-p.quit:
-		return nil
-	default:
+	p.closeOnce.Do(func() {
 		close(p.quit)
-	}
+	})
 	p.wg.Wait()
 	return p.embedder.Close()
 }

--- a/pkg/cache/embedder/pool.go
+++ b/pkg/cache/embedder/pool.go
@@ -1,0 +1,120 @@
+package embedder
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+const (
+	defaultPoolSize  = 4
+	defaultPoolQueue = 256
+)
+
+type PoolConfig struct {
+	Size  int `yaml:"size"`
+	Queue int `yaml:"queue"`
+}
+
+type job struct {
+	ctx    context.Context
+	req    EmbedRequest
+	result chan Embedding
+	err    chan error
+}
+
+type Pool struct {
+	embedder Embedder
+	jobs     chan job
+	wg       sync.WaitGroup
+	quit     chan struct{}
+	logger   *slog.Logger
+}
+
+func NewPool(embedder Embedder, cfg PoolConfig, logger *slog.Logger) *Pool {
+	if cfg.Size <= 0 {
+		cfg.Size = defaultPoolSize
+	}
+	if cfg.Queue <= 0 {
+		cfg.Queue = defaultPoolQueue
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	p := &Pool{
+		embedder: embedder,
+		jobs:     make(chan job, cfg.Queue),
+		quit:     make(chan struct{}),
+		logger:   logger,
+	}
+
+	for i := 0; i < cfg.Size; i++ {
+		p.wg.Add(1)
+		go p.worker(i)
+	}
+
+	return p
+}
+
+func (p *Pool) worker(id int) {
+	defer p.wg.Done()
+	p.logger.Debug("embedder pool worker started", "worker_id", id)
+	for {
+		select {
+		case j := <-p.jobs:
+			emb, err := p.embedder.Embed(j.ctx, j.req)
+			if err != nil {
+				j.err <- err
+			} else {
+				j.result <- emb
+			}
+		case <-p.quit:
+			p.logger.Debug("embedder pool worker stopped", "worker_id", id)
+			return
+		}
+	}
+}
+
+func (p *Pool) Embed(ctx context.Context, req EmbedRequest) (<-chan Embedding, <-chan error) {
+	j := job{
+		ctx:    ctx,
+		req:    req,
+		result: make(chan Embedding, 1),
+		err:    make(chan error, 1),
+	}
+	select {
+	case p.jobs <- j:
+	default:
+		err := make(chan error, 1)
+		err <- ErrPoolFull
+		close(err)
+		result := make(chan Embedding, 1)
+		close(result)
+		return result, err
+	}
+	return j.result, j.err
+}
+
+var ErrPoolFull = &poolFullError{}
+
+type poolFullError struct{}
+
+func (e *poolFullError) Error() string {
+	return "embedder pool queue full"
+}
+
+func (e *poolFullError) Unwrap() error {
+	return nil
+}
+
+func (p *Pool) Close() error {
+	select {
+	case <-p.quit:
+		return nil
+	default:
+		close(p.quit)
+	}
+	p.wg.Wait()
+	return p.embedder.Close()
+}

--- a/pkg/cache/embedder/pool.go
+++ b/pkg/cache/embedder/pool.go
@@ -34,11 +34,20 @@ func (p PoolConfig) withDefaults() PoolConfig {
 	return p
 }
 
+// EmbedOutcome is what pool.Embed sends back: either a successful Embedding
+// (Err == nil) or an error (Embedding zero-valued). One value, one close —
+// callers can read with `case out := <-ch:` and never have to race between
+// two channels.
+type EmbedOutcome struct {
+	Embedding Embedding
+	Err       error
+}
+
 type job struct {
 	ctx    context.Context
+	cancel context.CancelFunc
 	req    EmbedRequest
-	result chan Embedding
-	err    chan error
+	out    chan EmbedOutcome
 }
 
 type Pool struct {
@@ -47,6 +56,8 @@ type Pool struct {
 	wg        sync.WaitGroup
 	quit      chan struct{}
 	closeOnce sync.Once
+	shutdown  context.Context
+	cancelAll context.CancelFunc
 	logger    *slog.Logger
 	size      int
 }
@@ -57,12 +68,16 @@ func NewPool(embedder Embedder, cfg PoolConfig, logger *slog.Logger) *Pool {
 		logger = slog.Default()
 	}
 
+	shutdownCtx, cancelAll := context.WithCancel(context.Background())
+
 	p := &Pool{
-		embedder: embedder,
-		jobs:     make(chan job, cfg.Queue),
-		quit:     make(chan struct{}),
-		logger:   logger,
-		size:     cfg.Size,
+		embedder:  embedder,
+		jobs:      make(chan job, cfg.Queue),
+		quit:      make(chan struct{}),
+		shutdown:  shutdownCtx,
+		cancelAll: cancelAll,
+		logger:    logger,
+		size:      cfg.Size,
 	}
 
 	for i := 0; i < cfg.Size; i++ {
@@ -79,20 +94,7 @@ func (p *Pool) worker(id int) {
 	for {
 		select {
 		case j := <-p.jobs:
-			if err := j.ctx.Err(); err != nil {
-				j.err <- err
-				close(j.result)
-				close(j.err)
-				continue
-			}
-			emb, err := p.embedder.Embed(j.ctx, j.req)
-			if err != nil {
-				j.err <- err
-			} else {
-				j.result <- emb
-			}
-			close(j.result)
-			close(j.err)
+			p.handleJob(j)
 		case <-p.quit:
 			p.logger.Debug("embedder pool worker stopped", "worker_id", id)
 			return
@@ -100,21 +102,47 @@ func (p *Pool) worker(id int) {
 	}
 }
 
-func (p *Pool) Embed(ctx context.Context, req EmbedRequest) (<-chan Embedding, <-chan error) {
-	j := job{
-		ctx:    ctx,
-		req:    req,
-		result: make(chan Embedding, 1),
-		err:    make(chan error, 1),
+func (p *Pool) handleJob(j job) {
+	defer j.cancel()
+	defer close(j.out)
+
+	if err := j.ctx.Err(); err != nil {
+		j.out <- EmbedOutcome{Err: err}
+		return
 	}
+
+	emb, err := p.embedder.Embed(j.ctx, j.req)
+	j.out <- EmbedOutcome{Embedding: emb, Err: err}
+}
+
+func (p *Pool) Embed(ctx context.Context, req EmbedRequest) <-chan EmbedOutcome {
+	embedCtx, cancel := context.WithCancel(ctx)
+	j := job{
+		ctx:    embedCtx,
+		cancel: cancel,
+		req:    req,
+		out:    make(chan EmbedOutcome, 1),
+	}
+
 	select {
 	case p.jobs <- j:
-		return j.result, j.err
+		// Job accepted by queue. Tie embedCtx to pool shutdown so Close()
+		// interrupts in-flight HTTP calls. Spawn AFTER push to keep the
+		// pool-full path goroutine-free.
+		go func() {
+			select {
+			case <-p.shutdown.Done():
+				cancel()
+			case <-embedCtx.Done():
+			}
+		}()
+		return j.out
 	default:
-		j.err <- ErrPoolFull
-		close(j.result)
-		close(j.err)
-		return j.result, j.err
+		// Pool full: cancel the local ctx and deliver ErrPoolFull synchronously.
+		cancel()
+		j.out <- EmbedOutcome{Err: ErrPoolFull}
+		close(j.out)
+		return j.out
 	}
 }
 
@@ -134,8 +162,19 @@ func (p *Pool) Size() int {
 	return p.size
 }
 
+// Provider returns the underlying embedder's provider (ollama, openai, ...).
+func (p *Pool) Provider() Provider {
+	if p == nil || p.embedder == nil {
+		return ""
+	}
+	return p.embedder.Provider()
+}
+
 func (p *Pool) Close() error {
 	p.closeOnce.Do(func() {
+		// Cancel all in-flight jobs first; their HTTP calls will return ctx.Err().
+		p.cancelAll()
+		// Then signal workers to stop accepting new jobs.
 		close(p.quit)
 	})
 	p.wg.Wait()


### PR DESCRIPTION
## Summary

Implements Story 12.1 — embedding of outbound tool-call payloads using a local (Ollama) or remote (OpenAI) model, enabling semantic cache lookups in follow-up stories (12.2, 12.3).

Closes #218

## Changes

### New package: `pkg/cache/embedder/`

| File | Purpose |
|------|---------|
| `embedder.go` | `Embedder` interface, `EmbedRequest` / `Embedding` types, `Config` with validation |
| `ollama.go` | Ollama embedder — calls `/api/embed` on local Ollama; configurable URL + model |
| `openai.go` | OpenAI embedder — calls `POST /v1/embeddings`; key from `OPENAI_API_KEY` env or config |
| `pool.go` | Goroutine worker pool for lazy (non-blocking) embedding; configurable size + queue depth |

### Integration: `pkg/bouncer/embed.go`

- Global embed pool with `SetGlobalEmbedPool` / `GlobalEmbedPool` accessors
- `EmbedToolCall(ctx, req)` — submits async embed job via the pool
- `MustSetupEmbedder(cfg, poolCfg)` — one-shot init from config

### CLI flags added to `cmd/serve.go`

- `--embed-provider` (default: `""` disabled) — `ollama` or `openai`
- `--ollama-url` (default: `http://localhost:11434`)
- `--ollama-model` (default: `nomic-embed-text`)
- `--openai-model` (default: `text-embedding-3-small`)
- `--embed-pool-size` (default: `4`)

### Outbound hook

`injectBreakpoints` in `cmd/serve.go` now calls `embedOutboundPayload` to lazily submit embedding jobs for every outbound tool-call payload when embedder pool is configured.

## Testing

- **42 new tests** added (25 embedder + 17 bouncer)
- **1350 total tests passing** — no regression
- `go vet` clean, `gofmt` compliant

## Usage

```bash
# Local Ollama
leanproxy-mcp serve --embed-provider ollama

# Remote OpenAI
export OPENAI_API_KEY="sk-..."
leanproxy-mcp serve --embed-provider openai

# Custom pool size
leanproxy-mcp serve --embed-provider ollama --embed-pool-size 8
```
