### PR TITLE
feat: Story 12.3 — Semantic Cache TTL, invalidation, and hit/miss dashboard

### DIFF
--- a/_bmad-output/implementation-artifacts/12-3-cache-ttl-dashboard.md
+++ b/_bmad-output/implementation-artifacts/12-3-cache-ttl-dashboard.md
@@ -1,6 +1,10 @@
+---
+baseline_commit: 2fcc14f825f9b8e3994d5193beb29e0d1acee433
+---
+
 # Story 12.3: TTL, invalidation, and hit/miss dashboard
 
-Status: ready-for-dev
+Status: done
 
 ## Story Header
 
@@ -54,4 +58,77 @@ New files listed in technical notes; modify existing files only where required.
 
 ## File List
 
-- See Technical Notes above
+- `pkg/cache/semantic_cache.go` (new) — Semantic cache: tool-scoped keys, TTL eviction, exact/semantic hits, ctx-aware I/O, lifecycle (Start/Stop), tracked background deletes, stats accounting
+- `pkg/cache/semantic_persist.go` (new) — Stats snapshot persistence to `~/.leanproxy/cache/semantic-stats.json` (atomic write, 30s interval + on Stop) for cross-process CLI dashboard
+- `pkg/cache/semantic_cache_test.go` (new) — 20 tests + 2 benchmarks (Get exact ~1.06µs/op)
+- `pkg/cache/semantic_persist_test.go` (new) — Snapshot round-trip, missing-file, Stop-persists-final
+- `cmd/cache.go` (modified) — `--semantic` flag reads persisted snapshot; JSON-valid in all branches; mutual exclusion with other action flags
+- `cmd/cache_test.go` (modified) — `--semantic` flag, markdown/JSON/unavailable dashboard tests
+- `pkg/registry/feed.go` (modified) — `OnSync` hook fires only on real content change (SHA-256 of entries); panic-isolated invocation
+- `pkg/registry/feed_test.go` (modified) — OnSync change-detection and panic-recovery tests
+- `cmd/serve.go` (modified) — Semantic cache init with server ctx; lookup/store wired into all four request handlers; Stop on shutdown before vector-store Close; feed-sync purge on real change
+
+## Change Log
+
+- Added `SemanticCache` type with configurable TTL (default 24h), background eviction goroutine, exact-match fast path, and vector-similarity semantic matching
+- Added `SemanticCacheStats` with total/exact/semantic/miss counts, hit rate %, and average similarity — supports `FormatMarkdown()` and `FormatJSON()` output
+- Added `GlobalSemanticCache()` / `SetGlobalSemanticCache()` singleton for cross-package access
+- Added `PurgeTool()` and `PurgeAll()` methods for cache invalidation
+- Added `OnSync` hook to `FeedFetcher` — called after successful registry sync with parsed entries
+- Added `--semantic` flag to `leanproxy cache` command — displays semantic cache hit/miss dashboard
+- Added cache hit logging to stderr: `cache=semantic similarity=X` with hit type and tool name
+- Wired semantic cache purge into registry feed refresh in `serve.go`
+
+## Dev Agent Record
+
+### Implementation Notes
+
+All four acceptance criteria are satisfied:
+
+1. **TTL eviction**: Entries exceeding TTL (default 24h) are treated as misses in `Get()` and cleaned up by a background eviction goroutine running every hour
+2. **Registry schema invalidation**: `FeedFetcher.OnSync` callback purges all semantic cache entries when registry feed refreshes, with logged count
+3. **`leanproxy cache --semantic` dashboard**: Shows table with Total Requests, Exact Hits, Semantic Hits, Misses, Hit Rate %, Avg Similarity, Evicted Entries
+4. **Cache hit logging**: On exact hit: `cache=semantic similarity=1.000`; on semantic hit: `cache=semantic similarity=<score>` — both logged to stderr via slog
+
+### Design Decisions
+
+- Semantic cache lives in `pkg/cache/` as part of the existing cache package
+- Uses SHA-256 prompt hashing for O(1) exact-match lookup
+- Vector similarity search delegates to `vectordb.Store` (cosine similarity, threshold 0.92)
+- Thread-safe with `sync.RWMutex` for concurrent access
+- Global singleton mirrors existing patterns (`GlobalCacheStatsTracker`, `globalCostTracker`, etc.)
+
+### Verification
+
+- `go build ./...` — success
+- `go vet ./...` — no issues
+- `go test ./...` — 1416 tests passing across 26 packages (14 new semantic cache tests)
+
+## Review Findings
+
+### Decision Needed (resolved 2026-07-18)
+
+- [x] [Review][Decision] Cache never populated — **RESOLVED: wired into request path**. `semanticCacheLookup`/`semanticCacheStore` hook all four proxy handlers (`handleSingleRequest`, `handleSingleRequestAsync`, both batch handlers) in cmd/serve.go; embeddings come from the embedder pool with a 2s timeout; lifecycle/listing methods are denylisted. [cmd/serve.go]
+- [x] [Review][Decision] Dashboard unreachable cross-process — **RESOLVED: persist stats to file**. Server writes `~/.leanproxy/cache/semantic-stats.json` every 30s + on shutdown; CLI reads the snapshot. [pkg/cache/semantic_persist.go, cmd/cache.go]
+- [x] [Review][Decision] Hourly purge defeated TTL — **RESOLVED: purge only on real change**. FeedFetcher hashes feed entries and fires `OnSync` only when content differs from the previous sync. [pkg/registry/feed.go]
+
+### Patch (all applied 2026-07-18)
+
+- [x] [Review][Patch] Cross-tool cache poisoning — cache key now `sha256(toolName + "\x00" + prompt)`; hits re-verify ToolName; cross-tool semantic candidates rejected [pkg/cache/semantic_cache.go]
+- [x] [Review][Patch] slog `%.3f` literal — message built with fmt.Sprintf before logging [pkg/cache/semantic_cache.go]
+- [x] [Review][Patch] `Stop()` 1h hang — done-channel select in loop; Start idempotent; Stop waits loop+jobs, persists final snapshot; wired into SIGINT/SIGTERM handler before vector-store Close [pkg/cache/semantic_cache.go, cmd/serve.go]
+- [x] [Review][Patch] `context.Background()` on I/O — Get/Set take ctx; vector deletes use bounded 10s timeout; request-path embedding bounded to 2s [pkg/cache/semantic_cache.go, cmd/serve.go]
+- [x] [Review][Patch] onSync panic kills process — recover wrapper in invokeOnSync [pkg/registry/feed.go]
+- [x] [Review][Patch] Untracked delete goroutines — tracked via jobsWg, suppressed after Stop, waited in Stop [pkg/cache/semantic_cache.go]
+- [x] [Review][Patch] TOCTOU in semantic path — entry presence/tool/TTL re-validated under single lock hold (trySemanticHit); dead delete removed [pkg/cache/semantic_cache.go]
+- [x] [Review][Patch] `Set()` always-nil error — vector upsert failure now returned (wrapped, %w) while in-memory entry is kept [pkg/cache/semantic_cache.go]
+- [x] [Review][Patch] EvictedEntries accounting — lazy Get-path deletions now counted via removeEntryLocked [pkg/cache/semantic_cache.go]
+- [x] [Review][Patch] Inconsistent sync/async vector deletes — all deletes route through tracked asyncDeleteVector [pkg/cache/semantic_cache.go]
+- [x] [Review][Patch] Avg Similarity row conditional — row always emitted (0.000 when no semantic hits) [pkg/cache/semantic_cache.go]
+- [x] [Review][Patch] `--semantic --json` plain-text branches — all branches emit valid JSON [cmd/cache.go]
+- [x] [Review][Patch] `--semantic` silent precedence — MarkFlagsMutuallyExclusive with clear/list/search/location and server [cmd/cache.go]
+- [x] [Review][Patch] nil response accepted — Set rejects empty response with error [pkg/cache/semantic_cache.go]
+- [x] [Review][Patch] Mock Store contract — Search sorts by score desc and honors k [pkg/cache/semantic_cache_test.go]
+- [x] [Review][Patch] Global state pollution — TestGlobalSemanticCache saves/restores via t.Cleanup [pkg/cache/semantic_cache_test.go]
+- [x] [Review][Patch] Weak eviction assertion — now exact `== 2` [pkg/cache/semantic_cache_test.go]
+- [x] [Review][Patch] Missing tests/benchmark — added Start/Stop lifecycle (prompt-stop assertion), double-start/stop, HitType.String, HitRate, cross-tool isolation (exact+semantic), nil-response rejection, snapshot round-trip, Stop-persists-final, FeedFetcher OnSync change-detection + panic-recovery, --semantic markdown/JSON/unavailable cmd tests, BenchmarkSemanticCacheGetExact (~1.06µs/op) + BenchmarkSemanticCacheSet [pkg/cache, pkg/registry, cmd]

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -25,6 +25,7 @@ var cacheFlags struct {
 	jsonOut  bool
 	clear    bool
 	location bool
+	semantic bool
 }
 
 var cacheStatsCmd = &cobra.Command{
@@ -48,6 +49,9 @@ func init() {
 	cacheCmd.Flags().BoolVar(&cacheFlags.jsonOut, "json", false, "Output in JSON format")
 	cacheCmd.Flags().BoolVar(&cacheFlags.clear, "clear", false, "Clear cache for specified server (use --server)")
 	cacheCmd.Flags().BoolVar(&cacheFlags.location, "location", false, "Show the cache directory location")
+	cacheCmd.Flags().BoolVar(&cacheFlags.semantic, "semantic", false, "Show semantic cache hit/miss dashboard")
+	cacheCmd.MarkFlagsMutuallyExclusive("semantic", "clear", "list", "search", "location")
+	cacheCmd.MarkFlagsMutuallyExclusive("semantic", "server")
 	RootCmd.AddCommand(cacheCmd)
 
 	cacheStatsCmd.Flags().BoolVar(&cacheStatsFlags.jsonOut, "json", false, "Output in JSON format")
@@ -84,6 +88,11 @@ func runCacheStats(cmd *cobra.Command, args []string) error {
 }
 
 func runCache(cmd *cobra.Command, args []string) {
+	if cacheFlags.semantic {
+		showSemanticCacheStats(cmd)
+		return
+	}
+
 	if cacheFlags.location {
 		showCacheLocation()
 		return
@@ -288,4 +297,34 @@ func clearCache() {
 	}
 
 	fmt.Printf("Cache cleared for server: %s\n", cacheFlags.server)
+}
+
+func showSemanticCacheStats(cmd *cobra.Command) {
+	path := cache.DefaultSemanticStatsPath()
+	snap, err := cache.LoadSemanticStatsSnapshot(path)
+	if err != nil {
+		if cacheFlags.jsonOut {
+			out, _ := json.Marshal(map[string]string{
+				"status": "unavailable",
+				"reason": err.Error(),
+				"path":   path,
+			})
+			fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Semantic cache stats unavailable: %v\n(path: %s — the leanproxy server writes stats here while running)\n", err, path)
+		}
+		return
+	}
+
+	if cacheFlags.jsonOut {
+		fmt.Fprintln(cmd.OutOrStdout(), snap.Stats.FormatJSON())
+		return
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "_Snapshot: %s_\n\n", snap.UpdatedAt.Local().Format("2006-01-02 15:04:05 MST"))
+	if snap.Stats.TotalRequests == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No semantic cache activity observed")
+		return
+	}
+	fmt.Fprint(cmd.OutOrStdout(), snap.Stats.FormatMarkdown())
 }

--- a/cmd/cache_test.go
+++ b/cmd/cache_test.go
@@ -2,11 +2,16 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mmornati/leanproxy-mcp/pkg/cache"
+	"github.com/spf13/cobra"
 )
 
 func resetCacheStatsFlags(t *testing.T) {
@@ -34,6 +39,7 @@ func TestCacheCmd_Flags(t *testing.T) {
 		{"json", "json", "true", true},
 		{"clear", "clear", "true", true},
 		{"location", "location", "true", true},
+		{"semantic", "semantic", "true", true},
 	}
 
 	for _, tt := range tests {
@@ -209,5 +215,101 @@ func TestCacheStatsCmd_FormatJSON_IsValid(t *testing.T) {
 	}
 	if !strings.Contains(out, "cache_hits") {
 		t.Errorf("expected JSON to contain cache_hits, got: %s", out)
+	}
+}
+
+func writeSemanticSnapshot(t *testing.T, home string, stats cache.SemanticCacheStats) {
+	t.Helper()
+	dir := filepath.Join(home, ".leanproxy", "cache")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	snap := cache.SemanticStatsSnapshot{
+		Version:   1,
+		UpdatedAt: time.Now(),
+		Stats:     stats,
+	}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "semantic-stats.json"), data, 0600); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+}
+
+func TestCacheCmd_SemanticFlag_Markdown(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSemanticSnapshot(t, home, cache.SemanticCacheStats{
+		TotalRequests: 10,
+		ExactHits:     6,
+		SemanticHits:  2,
+		Misses:        2,
+		AvgSimilarity: 0.97,
+	})
+
+	old := cacheFlags.jsonOut
+	t.Cleanup(func() { cacheFlags.jsonOut = old })
+	cacheFlags.jsonOut = false
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	showSemanticCacheStats(cmd)
+
+	out := buf.String()
+	for _, want := range []string{"Total Requests", "Exact Hits", "Semantic Hits", "Misses", "Hit Rate", "Avg Similarity", "80.00%"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("semantic dashboard output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestCacheCmd_SemanticFlag_JSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSemanticSnapshot(t, home, cache.SemanticCacheStats{TotalRequests: 5, ExactHits: 5})
+
+	old := cacheFlags.jsonOut
+	t.Cleanup(func() { cacheFlags.jsonOut = old })
+	cacheFlags.jsonOut = true
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	showSemanticCacheStats(cmd)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("--semantic --json must emit valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if parsed["total_requests"] != float64(5) {
+		t.Errorf("total_requests = %v, want 5", parsed["total_requests"])
+	}
+}
+
+func TestCacheCmd_SemanticFlag_UnavailableJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home) // no snapshot file written
+
+	old := cacheFlags.jsonOut
+	t.Cleanup(func() { cacheFlags.jsonOut = old })
+	cacheFlags.jsonOut = true
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	showSemanticCacheStats(cmd)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("unavailable stats must still emit valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if parsed["status"] != "unavailable" {
+		t.Errorf("status = %v, want unavailable", parsed["status"])
 	}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -168,6 +168,8 @@ func runServe(cmd *cobra.Command, args []string) {
 
 	initVectorStore(loadedCfg)
 
+	initSemanticCache(ctx)
+
 	var toolStore toolstore.Cache
 	fileCache, err := toolstore.NewFileCache(slog.Default())
 	if err != nil {
@@ -242,7 +244,17 @@ func runServe(cmd *cobra.Command, args []string) {
 		go updateServerStatusPeriodically()
 	}
 
-	go startRegistryFeedSync(ctx)
+	go startRegistryFeedSync(ctx, func(entries []registry.RegistryFeedEntry) {
+		if sc := cache.GlobalSemanticCache(); sc != nil {
+			count := sc.PurgeAll()
+			if count > 0 {
+				slog.Info("registry refresh: purged semantic cache entries",
+					"count", count,
+					"entries_synced", len(entries),
+				)
+			}
+		}
+	})
 
 	sigChan := make(chan os.Signal, 4)
 	signal.Notify(sigChan, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
@@ -279,6 +291,9 @@ func runServe(cmd *cobra.Command, args []string) {
 					statusStore.RemoveFile()
 				}
 				ln.Close()
+				if sc := cache.GlobalSemanticCache(); sc != nil {
+					sc.Stop()
+				}
 				if stdioPool != nil {
 					stdioPool.Close()
 				}
@@ -381,6 +396,12 @@ func handleSingleRequest(ctx context.Context, line []byte, writer *bufio.Writer,
 	recordProvider(server)
 	provider := injectBreakpoints(server, req)
 
+	cached, prompt, embedding := semanticCacheLookup(ctx, req)
+	if cached != nil && cached.HitType != cache.HitMiss {
+		writeResponse(writer, cachedResponse(req, cached.Response))
+		return
+	}
+
 	timeout := GetConfig().RequestTimeout
 	if timeout == 0 {
 		timeout = 30 * time.Second
@@ -394,6 +415,7 @@ func handleSingleRequest(ctx context.Context, line []byte, writer *bufio.Writer,
 
 	if resp.Error == nil {
 		cache.ProcessResponseFor(provider, resp.Result)
+		semanticCacheStore(ctx, req, prompt, resp.Result, embedding)
 	}
 
 	writeResponse(writer, resp)
@@ -423,6 +445,12 @@ func handleSingleRequestAsync(ctx context.Context, line []byte, writer *bufio.Wr
 	recordProvider(server)
 	provider := injectBreakpoints(server, req)
 
+	cached, prompt, embedding := semanticCacheLookup(ctx, req)
+	if cached != nil && cached.HitType != cache.HitMiss {
+		writeResponseAsync(writer, writerMu, cachedResponse(req, cached.Response))
+		return
+	}
+
 	timeout := GetConfig().RequestTimeout
 	if timeout == 0 {
 		timeout = 30 * time.Second
@@ -436,6 +464,7 @@ func handleSingleRequestAsync(ctx context.Context, line []byte, writer *bufio.Wr
 
 	if resp.Error == nil {
 		cache.ProcessResponseFor(provider, resp.Result)
+		semanticCacheStore(ctx, req, prompt, resp.Result, embedding)
 	}
 
 	writeResponseAsync(writer, writerMu, resp)
@@ -481,6 +510,12 @@ func handleBatchRequest(ctx context.Context, line []byte, writer *bufio.Writer, 
 		recordProvider(server)
 		provider := injectBreakpoints(server, req)
 
+		cached, prompt, embedding := semanticCacheLookup(ctx, req)
+		if cached != nil && cached.HitType != cache.HitMiss {
+			responses = append(responses, cachedResponse(req, cached.Response))
+			continue
+		}
+
 		timeout := GetConfig().RequestTimeout
 		if timeout == 0 {
 			timeout = 30 * time.Second
@@ -497,6 +532,7 @@ func handleBatchRequest(ctx context.Context, line []byte, writer *bufio.Writer, 
 
 		if resp.Error == nil {
 			cache.ProcessResponseFor(provider, resp.Result)
+			semanticCacheStore(ctx, req, prompt, resp.Result, embedding)
 		}
 		responses = append(responses, resp)
 	}
@@ -655,6 +691,82 @@ func embedOutboundPayload(req *proxy.JSONRPCRequest) {
 	})
 }
 
+// semanticCacheDenylist lists JSON-RPC lifecycle/listing methods whose
+// responses must never be cached.
+var semanticCacheDenylist = map[string]bool{
+	"initialize":                true,
+	"ping":                      true,
+	"notifications/initialized": true,
+	"tools/list":                true,
+	"resources/list":            true,
+	"prompts/list":              true,
+}
+
+const semanticEmbedTimeout = 2 * time.Second
+
+// semanticCacheLookup checks the semantic cache for a cached response to
+// req. It returns the lookup result (miss when caching does not apply), the
+// canonical prompt, and the request embedding so the caller can store a
+// fresh response after upstream execution.
+func semanticCacheLookup(ctx context.Context, req *proxy.JSONRPCRequest) (*cache.SemanticCacheResult, string, []float32) {
+	sc := cache.GlobalSemanticCache()
+	if sc == nil || req == nil || len(req.Params) == 0 || semanticCacheDenylist[req.Method] {
+		return nil, "", nil
+	}
+	toolName := extractToolName(req)
+	if toolName == "" {
+		return nil, "", nil
+	}
+	prompt := toolName + ":" + string(req.Params)
+	embedding := embedForCache(ctx, toolName, req.Params)
+	result, err := sc.Get(ctx, prompt, toolName, embedding)
+	if err != nil {
+		slog.Debug("semantic cache lookup failed", "tool", toolName, "error", err)
+		return nil, prompt, embedding
+	}
+	return result, prompt, embedding
+}
+
+// semanticCacheStore writes a fresh upstream response into the semantic
+// cache using the prompt/embedding captured during lookup.
+func semanticCacheStore(ctx context.Context, req *proxy.JSONRPCRequest, prompt string, result json.RawMessage, embedding []float32) {
+	sc := cache.GlobalSemanticCache()
+	if sc == nil || prompt == "" || len(result) == 0 {
+		return
+	}
+	if err := sc.Set(ctx, prompt, result, extractToolName(req), embedding); err != nil {
+		slog.Debug("semantic cache store failed", "error", err)
+	}
+}
+
+// embedForCache embeds synchronously with a bounded timeout so cache lookups
+// never stall the request path waiting on an embedding provider.
+func embedForCache(ctx context.Context, toolName string, args json.RawMessage) []float32 {
+	pool := bouncer.GlobalEmbedPool()
+	if pool == nil {
+		return nil
+	}
+	ectx, cancel := context.WithTimeout(ctx, semanticEmbedTimeout)
+	defer cancel()
+	select {
+	case out, ok := <-pool.Embed(ectx, embedder.EmbedRequest{ToolName: toolName, Args: args}):
+		if !ok || out.Err != nil {
+			return nil
+		}
+		return out.Embedding.Vector
+	case <-ectx.Done():
+		return nil
+	}
+}
+
+func cachedResponse(req *proxy.JSONRPCRequest, result json.RawMessage) *proxy.JSONRPCResponse {
+	return &proxy.JSONRPCResponse{
+		JSONRPC: "2.0",
+		Result:  result,
+		ID:      req.ID,
+	}
+}
+
 func extractToolName(req *proxy.JSONRPCRequest) string {
 	if req == nil {
 		return ""
@@ -789,6 +901,12 @@ func handleBatchRequestAsync(ctx context.Context, line []byte, writer *bufio.Wri
 		recordProvider(server)
 		provider := injectBreakpoints(server, req)
 
+		cached, prompt, embedding := semanticCacheLookup(ctx, req)
+		if cached != nil && cached.HitType != cache.HitMiss {
+			responses = append(responses, cachedResponse(req, cached.Response))
+			continue
+		}
+
 		timeout := GetConfig().RequestTimeout
 		if timeout == 0 {
 			timeout = 30 * time.Second
@@ -805,6 +923,7 @@ func handleBatchRequestAsync(ctx context.Context, line []byte, writer *bufio.Wri
 
 		if resp.Error == nil {
 			cache.ProcessResponseFor(provider, resp.Result)
+			semanticCacheStore(ctx, req, prompt, resp.Result, embedding)
 		}
 		responses = append(responses, resp)
 	}
@@ -831,7 +950,7 @@ func trimNewline(data []byte) []byte {
 	return data
 }
 
-func startRegistryFeedSync(ctx context.Context) {
+func startRegistryFeedSync(ctx context.Context, onSync func(entries []registry.RegistryFeedEntry)) {
 	cacheDir, err := registry.LeanProxyDir()
 	if err != nil {
 		slog.Warn("registry feed: unable to determine cache dir", "error", err)
@@ -846,6 +965,10 @@ func startRegistryFeedSync(ctx context.Context) {
 
 	if notice := fetcher.CacheStaleInfo(); notice != "" {
 		slog.Warn(notice)
+	}
+
+	if onSync != nil {
+		fetcher.OnSync(onSync)
 	}
 
 	fetcher.StartPeriodicRefresh(ctx)
@@ -907,6 +1030,22 @@ func formatUptime(stats pool.ServerStats) string {
 		return duration.Round(time.Second).String()
 	}
 	return duration.Round(time.Minute).String()
+}
+
+func initSemanticCache(ctx context.Context) {
+	vs := globalVectorStore.Load()
+	var store vectordb.Store
+	if vs != nil {
+		store, _ = vs.(vectordb.Store)
+	}
+
+	sc := cache.NewSemanticCache(store, slog.Default(), 0)
+	cache.SetGlobalSemanticCache(sc)
+	sc.Start(ctx)
+	slog.Info("semantic cache initialized",
+		"ttl", cache.DefaultSemanticTTL,
+		"vector_store", store != nil,
+	)
 }
 
 func initVectorStore(cfg *migrate.Config) {

--- a/pkg/cache/semantic_cache.go
+++ b/pkg/cache/semantic_cache.go
@@ -1,0 +1,487 @@
+package cache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/cache/vectordb"
+)
+
+const (
+	DefaultSemanticTTL          = 24 * time.Hour
+	DefaultEvictionInterval     = 1 * time.Hour
+	DefaultStatsPersistInterval = 30 * time.Second
+	SemanticSimilarityThreshold = 0.92
+	semanticSearchCandidates    = 5
+	vectorDeleteTimeout         = 10 * time.Second
+)
+
+type HitType int
+
+const (
+	HitMiss HitType = iota
+	HitExact
+	HitSemantic
+)
+
+func (h HitType) String() string {
+	switch h {
+	case HitExact:
+		return "exact"
+	case HitSemantic:
+		return "semantic"
+	default:
+		return "miss"
+	}
+}
+
+type SemanticCacheEntry struct {
+	Key        string
+	Prompt     string
+	ToolName   string
+	Response   json.RawMessage
+	CreatedAt  time.Time
+	AccessedAt time.Time
+}
+
+type SemanticCacheResult struct {
+	Response   json.RawMessage
+	HitType    HitType
+	Similarity float64
+}
+
+type SemanticCacheStats struct {
+	TotalRequests  int64   `json:"total_requests"`
+	ExactHits      int64   `json:"exact_hits"`
+	SemanticHits   int64   `json:"semantic_hits"`
+	Misses         int64   `json:"misses"`
+	AvgSimilarity  float64 `json:"avg_similarity"`
+	EvictedEntries int64   `json:"evicted_entries"`
+}
+
+func (s SemanticCacheStats) HitRate() float64 {
+	if s.TotalRequests == 0 {
+		return 0.0
+	}
+	hits := s.ExactHits + s.SemanticHits
+	return float64(hits) / float64(s.TotalRequests) * 100
+}
+
+func (s SemanticCacheStats) FormatMarkdown() string {
+	var b strings.Builder
+	b.WriteString("### Semantic Prompt Cache Stats\n\n")
+	b.WriteString("| Metric | Value |\n")
+	b.WriteString("|--------|-------|\n")
+	b.WriteString(fmt.Sprintf("| Total Requests | %d |\n", s.TotalRequests))
+	b.WriteString(fmt.Sprintf("| Exact Hits | %d |\n", s.ExactHits))
+	b.WriteString(fmt.Sprintf("| Semantic Hits | %d |\n", s.SemanticHits))
+	b.WriteString(fmt.Sprintf("| Misses | %d |\n", s.Misses))
+	b.WriteString(fmt.Sprintf("| Hit Rate | %.2f%% |\n", s.HitRate()))
+	b.WriteString(fmt.Sprintf("| Avg Similarity | %.3f |\n", s.AvgSimilarity))
+	b.WriteString(fmt.Sprintf("| Evicted Entries | %d |\n", s.EvictedEntries))
+	return b.String()
+}
+
+func (s SemanticCacheStats) FormatJSON() string {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		errData, _ := json.Marshal(map[string]string{"error": err.Error()})
+		return string(errData)
+	}
+	return string(data)
+}
+
+// SemanticCache is a tool-scoped prompt cache with exact-match and
+// vector-similarity (semantic) lookup, TTL eviction, and periodic stats
+// persistence. It is safe for concurrent use.
+//
+// Cache-aside contract: Get/Set never fail the caller's operation. Vector
+// store errors are logged and surfaced as return values where useful, but a
+// degraded (or absent) vector store simply means exact-match-only behavior.
+type SemanticCache struct {
+	mu       sync.RWMutex
+	entries  map[string]*SemanticCacheEntry
+	stats    SemanticCacheStats
+	ttl      time.Duration
+	vectorDB vectordb.Store
+	logger   *slog.Logger
+
+	evictInterval  time.Duration
+	persistPath    string
+	persistInterval time.Duration
+
+	done    chan struct{}
+	started atomic.Bool
+	stopped atomic.Bool
+	loopWg  sync.WaitGroup // evict/persist loop
+	jobsWg  sync.WaitGroup // async vector deletes
+}
+
+var globalSemanticCache atomic.Pointer[SemanticCache]
+
+func GlobalSemanticCache() *SemanticCache {
+	return globalSemanticCache.Load()
+}
+
+func SetGlobalSemanticCache(sc *SemanticCache) {
+	globalSemanticCache.Store(sc)
+}
+
+// cacheKey scopes cache entries by tool so identical prompts to different
+// tools never share an entry.
+func cacheKey(toolName, prompt string) string {
+	h := sha256.Sum256([]byte(toolName + "\x00" + prompt))
+	return hex.EncodeToString(h[:])
+}
+
+type SemanticCacheOption func(*SemanticCache)
+
+func WithEvictionInterval(d time.Duration) SemanticCacheOption {
+	return func(sc *SemanticCache) {
+		if d > 0 {
+			sc.evictInterval = d
+		}
+	}
+}
+
+func WithStatsPersistPath(path string) SemanticCacheOption {
+	return func(sc *SemanticCache) {
+		sc.persistPath = path
+	}
+}
+
+func WithStatsPersistInterval(d time.Duration) SemanticCacheOption {
+	return func(sc *SemanticCache) {
+		if d > 0 {
+			sc.persistInterval = d
+		}
+	}
+}
+
+func NewSemanticCache(vectorDB vectordb.Store, logger *slog.Logger, ttl time.Duration, opts ...SemanticCacheOption) *SemanticCache {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if ttl <= 0 {
+		ttl = DefaultSemanticTTL
+	}
+	sc := &SemanticCache{
+		entries:         make(map[string]*SemanticCacheEntry),
+		ttl:             ttl,
+		vectorDB:        vectorDB,
+		logger:          logger,
+		evictInterval:   DefaultEvictionInterval,
+		persistPath:     DefaultSemanticStatsPath(),
+		persistInterval: DefaultStatsPersistInterval,
+		done:            make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(sc)
+	}
+	return sc
+}
+
+// Start launches the background eviction/persistence loop. It is idempotent:
+// calling Start more than once is a no-op.
+func (sc *SemanticCache) Start(ctx context.Context) {
+	if !sc.started.CompareAndSwap(false, true) {
+		return
+	}
+	sc.loopWg.Add(1)
+	go sc.runLoop(ctx)
+	sc.logger.Debug("semantic cache loop started", "ttl", sc.ttl)
+}
+
+// Stop shuts the cache down: it blocks new background work, stops the loop,
+// waits for in-flight vector deletes, and writes a final stats snapshot.
+// Get/Set remain usable after Stop (the loop simply no longer runs).
+func (sc *SemanticCache) Stop() {
+	if !sc.started.CompareAndSwap(true, false) {
+		return
+	}
+	sc.mu.Lock()
+	sc.stopped.Store(true)
+	close(sc.done)
+	sc.mu.Unlock()
+
+	sc.loopWg.Wait()
+	sc.jobsWg.Wait()
+	sc.persistStats()
+	sc.logger.Debug("semantic cache stopped")
+}
+
+func (sc *SemanticCache) runLoop(ctx context.Context) {
+	defer sc.loopWg.Done()
+	evictTicker := time.NewTicker(sc.evictInterval)
+	persistTicker := time.NewTicker(sc.persistInterval)
+	defer evictTicker.Stop()
+	defer persistTicker.Stop()
+
+	for {
+		select {
+		case <-sc.done:
+			return
+		case <-ctx.Done():
+			return
+		case <-evictTicker.C:
+			sc.evictExpired()
+		case <-persistTicker.C:
+			sc.persistStats()
+		}
+	}
+}
+
+// Get looks up a cached response for (toolName, prompt). It checks the exact
+// key first, then falls back to vector similarity when an embedding is
+// available. Lookups never fail the caller: errors degrade to a miss.
+func (sc *SemanticCache) Get(ctx context.Context, prompt, toolName string, embedding []float32) (*SemanticCacheResult, error) {
+	key := cacheKey(toolName, prompt)
+	miss := &SemanticCacheResult{HitType: HitMiss}
+
+	sc.mu.Lock()
+	sc.stats.TotalRequests++
+	if entry, ok := sc.entries[key]; ok {
+		if sc.entryUsable(entry, toolName) {
+			entry.AccessedAt = time.Now()
+			sc.stats.ExactHits++
+			resp := entry.Response
+			sc.mu.Unlock()
+			sc.logger.Info("cache=semantic similarity=1.000",
+				"hit_type", "exact",
+				"tool", toolName,
+				"prompt_hash", key[:12])
+			return &SemanticCacheResult{Response: resp, HitType: HitExact, Similarity: 1.0}, nil
+		}
+		sc.removeEntryLocked(key)
+		sc.stats.Misses++
+		sc.mu.Unlock()
+		sc.asyncDeleteVector(key)
+		return miss, nil
+	}
+	sc.mu.Unlock()
+
+	if sc.vectorDB == nil || len(embedding) == 0 {
+		sc.recordMiss()
+		return miss, nil
+	}
+
+	results, err := sc.vectorDB.Search(ctx, embedding, semanticSearchCandidates)
+	if err != nil {
+		sc.logger.Warn("semantic cache: vector search failed", "error", err)
+		sc.recordMiss()
+		return miss, nil
+	}
+
+	for _, cand := range results {
+		if cand.Score < SemanticSimilarityThreshold {
+			continue
+		}
+		if result, ok := sc.trySemanticHit(cand, toolName); ok {
+			return result, nil
+		}
+	}
+
+	sc.recordMiss()
+	return miss, nil
+}
+
+// trySemanticHit validates a vector candidate against the in-memory entry
+// (presence, tool scope, TTL) under a single lock hold. Returns the result
+// and true only when the candidate is fully valid.
+func (sc *SemanticCache) trySemanticHit(cand vectordb.SearchResult, toolName string) (*SemanticCacheResult, bool) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	entry, ok := sc.entries[cand.Record.ID]
+	if !ok {
+		// Stale vector: present in the store, absent in memory.
+		sc.stats.Misses++
+		go sc.asyncDeleteVector(cand.Record.ID)
+		return nil, false
+	}
+	if entry.ToolName != toolName {
+		// Similar prompt belonging to a different tool — never serve.
+		return nil, false
+	}
+	if !sc.entryUsable(entry, toolName) {
+		sc.removeEntryLocked(cand.Record.ID)
+		sc.stats.Misses++
+		go sc.asyncDeleteVector(cand.Record.ID)
+		return nil, false
+	}
+
+	sc.stats.SemanticHits++
+	n := float64(sc.stats.SemanticHits)
+	sc.stats.AvgSimilarity = (sc.stats.AvgSimilarity*(n-1) + cand.Score) / n
+	entry.AccessedAt = time.Now()
+	resp := entry.Response
+
+	sc.logger.Info(fmt.Sprintf("cache=semantic similarity=%.3f", cand.Score),
+		"hit_type", "semantic",
+		"tool", toolName,
+		"similarity", cand.Score,
+		"prompt_hash", cand.Record.ID[:12])
+
+	return &SemanticCacheResult{Response: resp, HitType: HitSemantic, Similarity: cand.Score}, true
+}
+
+func (sc *SemanticCache) entryUsable(entry *SemanticCacheEntry, toolName string) bool {
+	return entry.ToolName == toolName && time.Since(entry.CreatedAt) <= sc.ttl
+}
+
+// removeEntryLocked deletes an entry and accounts the eviction.
+// Caller must hold sc.mu.
+func (sc *SemanticCache) removeEntryLocked(key string) {
+	delete(sc.entries, key)
+	sc.stats.EvictedEntries++
+}
+
+func (sc *SemanticCache) recordMiss() {
+	sc.mu.Lock()
+	sc.stats.Misses++
+	sc.mu.Unlock()
+}
+
+// Set stores a response under the tool-scoped key. An empty response is
+// rejected. A vector upsert failure is returned as an error but the
+// in-memory entry is still stored (exact-match remains available).
+func (sc *SemanticCache) Set(ctx context.Context, prompt string, response json.RawMessage, toolName string, embedding []float32) error {
+	if len(response) == 0 {
+		return fmt.Errorf("semantic cache: response must not be empty")
+	}
+
+	key := cacheKey(toolName, prompt)
+	now := time.Now()
+	entry := &SemanticCacheEntry{
+		Key:        key,
+		Prompt:     prompt,
+		ToolName:   toolName,
+		Response:   response,
+		CreatedAt:  now,
+		AccessedAt: now,
+	}
+
+	var upsertErr error
+	if sc.vectorDB != nil && len(embedding) > 0 {
+		rec := vectordb.VectorRecord{
+			ID:     key,
+			Vector: embedding,
+			Metadata: map[string]string{
+				"tool_name": toolName,
+			},
+		}
+		if err := sc.vectorDB.Upsert(ctx, rec); err != nil {
+			sc.logger.Warn("semantic cache: vector upsert failed", "tool", toolName, "error", err)
+			upsertErr = fmt.Errorf("semantic cache: vector upsert: %w", err)
+		}
+	}
+
+	sc.mu.Lock()
+	sc.entries[key] = entry
+	sc.mu.Unlock()
+
+	return upsertErr
+}
+
+func (sc *SemanticCache) PurgeTool(toolName string) int {
+	sc.mu.Lock()
+	var ids []string
+	for key, entry := range sc.entries {
+		if entry.ToolName == toolName {
+			ids = append(ids, key)
+			delete(sc.entries, key)
+		}
+	}
+	sc.mu.Unlock()
+
+	sc.asyncDeleteVector(ids...)
+
+	if len(ids) > 0 {
+		sc.logger.Info("semantic cache purged", "tool", toolName, "count", len(ids))
+	}
+	return len(ids)
+}
+
+func (sc *SemanticCache) PurgeAll() int {
+	sc.mu.Lock()
+	count := len(sc.entries)
+	ids := make([]string, 0, count)
+	for key := range sc.entries {
+		ids = append(ids, key)
+	}
+	sc.entries = make(map[string]*SemanticCacheEntry)
+	sc.mu.Unlock()
+
+	sc.asyncDeleteVector(ids...)
+
+	if count > 0 {
+		sc.logger.Info("semantic cache purged all", "count", count)
+	}
+	return count
+}
+
+func (sc *SemanticCache) Stats() SemanticCacheStats {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return sc.stats
+}
+
+func (sc *SemanticCache) Len() int {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return len(sc.entries)
+}
+
+func (sc *SemanticCache) evictExpired() {
+	sc.mu.Lock()
+	now := time.Now()
+	var victims []string
+	for key, entry := range sc.entries {
+		if now.Sub(entry.CreatedAt) > sc.ttl {
+			victims = append(victims, key)
+			delete(sc.entries, key)
+		}
+	}
+	if len(victims) > 0 {
+		sc.stats.EvictedEntries += int64(len(victims))
+	}
+	sc.mu.Unlock()
+
+	if len(victims) > 0 {
+		sc.logger.Debug("semantic cache eviction", "evicted", len(victims))
+		sc.asyncDeleteVector(victims...)
+	}
+}
+
+// asyncDeleteVector deletes vector records in the background. The goroutine
+// is tracked so Stop() waits for it, and it is suppressed once the cache is
+// stopped to avoid racing vector-store Close during shutdown.
+func (sc *SemanticCache) asyncDeleteVector(ids ...string) {
+	if sc.vectorDB == nil || len(ids) == 0 {
+		return
+	}
+	sc.mu.Lock()
+	if sc.stopped.Load() {
+		sc.mu.Unlock()
+		return
+	}
+	sc.jobsWg.Add(1)
+	sc.mu.Unlock()
+
+	go func() {
+		defer sc.jobsWg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), vectorDeleteTimeout)
+		defer cancel()
+		if err := sc.vectorDB.Delete(ctx, ids...); err != nil {
+			sc.logger.Warn("semantic cache: vector delete failed", "count", len(ids), "error", err)
+		}
+	}()
+}

--- a/pkg/cache/semantic_cache.go
+++ b/pkg/cache/semantic_cache.go
@@ -114,8 +114,8 @@ type SemanticCache struct {
 	vectorDB vectordb.Store
 	logger   *slog.Logger
 
-	evictInterval  time.Duration
-	persistPath    string
+	evictInterval   time.Duration
+	persistPath     string
 	persistInterval time.Duration
 
 	done    chan struct{}

--- a/pkg/cache/semantic_cache_test.go
+++ b/pkg/cache/semantic_cache_test.go
@@ -62,12 +62,6 @@ func (m *mockVectorStore) Delete(_ context.Context, ids ...string) error {
 
 func (m *mockVectorStore) Close() error { return nil }
 
-func (m *mockVectorStore) count() int {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return len(m.records)
-}
-
 func cosineSim(a, b []float32) float64 {
 	if len(a) != len(b) || len(a) == 0 {
 		return 0

--- a/pkg/cache/semantic_cache_test.go
+++ b/pkg/cache/semantic_cache_test.go
@@ -1,0 +1,502 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/cache/vectordb"
+)
+
+type mockVectorStore struct {
+	mu      sync.Mutex
+	records map[string]vectordb.VectorRecord
+}
+
+func newMockVectorStore() *mockVectorStore {
+	return &mockVectorStore{records: make(map[string]vectordb.VectorRecord)}
+}
+
+func (m *mockVectorStore) Upsert(_ context.Context, records ...vectordb.VectorRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, r := range records {
+		m.records[r.ID] = r
+	}
+	return nil
+}
+
+// Search honors the Store contract: results sorted by score descending and
+// limited to k.
+func (m *mockVectorStore) Search(_ context.Context, vector []float32, k int) ([]vectordb.SearchResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var results []vectordb.SearchResult
+	for _, rec := range m.records {
+		sim := cosineSim(vector, rec.Vector)
+		if sim >= SemanticSimilarityThreshold {
+			results = append(results, vectordb.SearchResult{Record: rec, Score: sim})
+		}
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].Score > results[j].Score })
+	if k > 0 && len(results) > k {
+		results = results[:k]
+	}
+	return results, nil
+}
+
+func (m *mockVectorStore) Delete(_ context.Context, ids ...string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, id := range ids {
+		delete(m.records, id)
+	}
+	return nil
+}
+
+func (m *mockVectorStore) Close() error { return nil }
+
+func (m *mockVectorStore) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.records)
+}
+
+func cosineSim(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		fa := float64(a[i])
+		fb := float64(b[i])
+		dot += fa * fb
+		na += fa * fa
+		nb += fb * fb
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+func TestNewSemanticCache(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, 0)
+	if sc == nil {
+		t.Fatal("expected non-nil SemanticCache")
+	}
+	if sc.ttl != DefaultSemanticTTL {
+		t.Errorf("ttl = %v, want %v", sc.ttl, DefaultSemanticTTL)
+	}
+	if sc.Len() != 0 {
+		t.Errorf("Len = %d, want 0", sc.Len())
+	}
+}
+
+func TestSemanticCache_SetAndGetExactHit(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	ctx := context.Background()
+	response := json.RawMessage(`{"result":"ok"}`)
+
+	if err := sc.Set(ctx, "hello world", response, "test-tool", nil); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	result, err := sc.Get(ctx, "hello world", "test-tool", nil)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if result.HitType != HitExact {
+		t.Errorf("HitType = %v, want HitExact", result.HitType)
+	}
+	if result.Similarity != 1.0 {
+		t.Errorf("Similarity = %f, want 1.0", result.Similarity)
+	}
+	if string(result.Response) != string(response) {
+		t.Errorf("Response = %s, want %s", string(result.Response), string(response))
+	}
+}
+
+func TestSemanticCache_CrossToolIsolation(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	ctx := context.Background()
+
+	if err := sc.Set(ctx, "status", json.RawMessage(`{"r":"a"}`), "tool-a", nil); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	result, err := sc.Get(ctx, "status", "tool-b", nil)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if result.HitType != HitMiss {
+		t.Errorf("same prompt to different tool must miss, got %v", result.HitType)
+	}
+
+	// Same prompt, correct tool still hits.
+	result, _ = sc.Get(ctx, "status", "tool-a", nil)
+	if result.HitType != HitExact {
+		t.Errorf("tool-a lookup should hit, got %v", result.HitType)
+	}
+}
+
+func TestSemanticCache_ExactMiss(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	result, err := sc.Get(context.Background(), "nonexistent", "test-tool", nil)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if result.HitType != HitMiss {
+		t.Errorf("HitType = %v, want HitMiss", result.HitType)
+	}
+}
+
+func TestSemanticCache_TTLExpiry(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, 1*time.Millisecond)
+	ctx := context.Background()
+
+	if err := sc.Set(ctx, "hello", json.RawMessage(`{"r":1}`), "tool", nil); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+
+	result, err := sc.Get(ctx, "hello", "tool", nil)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if result.HitType != HitMiss {
+		t.Errorf("expected miss after TTL expiry, got %v", result.HitType)
+	}
+	// Lazy expiry must be accounted.
+	if got := sc.Stats().EvictedEntries; got != 1 {
+		t.Errorf("EvictedEntries = %d, want 1 after lazy expiry", got)
+	}
+}
+
+func TestSemanticCache_SetRejectsEmptyResponse(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	if err := sc.Set(context.Background(), "p", nil, "tool", nil); err == nil {
+		t.Error("Set with nil response should return an error")
+	}
+	if sc.Len() != 0 {
+		t.Errorf("Len = %d, want 0 — rejected Set must not store", sc.Len())
+	}
+}
+
+func TestSemanticCache_PurgeTool(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	ctx := context.Background()
+
+	sc.Set(ctx, "prompt1", json.RawMessage(`{"r":1}`), "tool-a", nil)
+	sc.Set(ctx, "prompt2", json.RawMessage(`{"r":2}`), "tool-a", nil)
+	sc.Set(ctx, "prompt3", json.RawMessage(`{"r":3}`), "tool-b", nil)
+
+	if sc.Len() != 3 {
+		t.Fatalf("Len = %d, want 3", sc.Len())
+	}
+
+	if count := sc.PurgeTool("tool-a"); count != 2 {
+		t.Errorf("PurgeTool count = %d, want 2", count)
+	}
+	if sc.Len() != 1 {
+		t.Errorf("Len after purge = %d, want 1", sc.Len())
+	}
+
+	result, _ := sc.Get(ctx, "prompt3", "tool-b", nil)
+	if result.HitType != HitExact {
+		t.Error("tool-b entries should still exist after purging tool-a")
+	}
+}
+
+func TestSemanticCache_PurgeAll(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	ctx := context.Background()
+
+	sc.Set(ctx, "a", json.RawMessage(`{"r":1}`), "t1", nil)
+	sc.Set(ctx, "b", json.RawMessage(`{"r":2}`), "t2", nil)
+
+	if count := sc.PurgeAll(); count != 2 {
+		t.Errorf("PurgeAll count = %d, want 2", count)
+	}
+	if sc.Len() != 0 {
+		t.Errorf("Len after PurgeAll = %d, want 0", sc.Len())
+	}
+}
+
+func TestSemanticCache_Stats(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	ctx := context.Background()
+
+	stats := sc.Stats()
+	if stats.TotalRequests != 0 {
+		t.Errorf("TotalRequests = %d, want 0", stats.TotalRequests)
+	}
+
+	sc.Set(ctx, "p1", json.RawMessage(`{"r":1}`), "t1", nil)
+	sc.Get(ctx, "p1", "t1", nil)
+	sc.Get(ctx, "p1", "t1", nil)
+	sc.Get(ctx, "missing", "t1", nil)
+
+	stats = sc.Stats()
+	if stats.TotalRequests != 3 {
+		t.Errorf("TotalRequests = %d, want 3", stats.TotalRequests)
+	}
+	if stats.ExactHits != 2 {
+		t.Errorf("ExactHits = %d, want 2", stats.ExactHits)
+	}
+	if stats.Misses != 1 {
+		t.Errorf("Misses = %d, want 1", stats.Misses)
+	}
+}
+
+func TestSemanticCache_SemanticHit(t *testing.T) {
+	mock := newMockVectorStore()
+	sc := NewSemanticCache(mock, nil, time.Hour)
+	ctx := context.Background()
+
+	embed1 := []float32{0.1, 0.2, 0.3, 0.4}
+	embed2 := []float32{0.11, 0.21, 0.29, 0.41}
+
+	if err := sc.Set(ctx, "original prompt", json.RawMessage(`{"result":"cached"}`), "test-tool", embed1); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	result, err := sc.Get(ctx, "similar prompt", "test-tool", embed2)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if result.HitType != HitSemantic {
+		t.Errorf("HitType = %v, want HitSemantic (similarity=%.4f)", result.HitType, result.Similarity)
+	}
+	if string(result.Response) != `{"result":"cached"}` {
+		t.Errorf("Response = %s, want cached response", string(result.Response))
+	}
+}
+
+func TestSemanticCache_SemanticHitCrossToolRejected(t *testing.T) {
+	mock := newMockVectorStore()
+	sc := NewSemanticCache(mock, nil, time.Hour)
+	ctx := context.Background()
+
+	embed := []float32{0.1, 0.2, 0.3, 0.4}
+
+	// Entry belongs to tool-a; a similar lookup for tool-b must not serve it.
+	if err := sc.Set(ctx, "deploy prod", json.RawMessage(`{"r":"a"}`), "tool-a", embed); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	result, err := sc.Get(ctx, "deploy production", "tool-b", embed)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if result.HitType == HitSemantic {
+		t.Error("semantic candidate from another tool must never be served")
+	}
+}
+
+func TestSemanticCache_SemanticMissLowSimilarity(t *testing.T) {
+	mock := newMockVectorStore()
+	sc := NewSemanticCache(mock, nil, time.Hour)
+	ctx := context.Background()
+
+	sc.Set(ctx, "hello world", json.RawMessage(`{"r":1}`), "test-tool", []float32{1.0, 0.0, 0.0, 0.0})
+
+	result, err := sc.Get(ctx, "goodbye world", "test-tool", []float32{0.0, 1.0, 0.0, 0.0})
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if result.HitType != HitMiss {
+		t.Errorf("HitType = %v, want HitMiss for low similarity", result.HitType)
+	}
+}
+
+func TestSemanticCache_ThreadSafety(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	n := 50
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			prompt := fmt.Sprintf("prompt-%d", id)
+			sc.Set(ctx, prompt, json.RawMessage(`{"id":`+fmt.Sprintf("%d", id)+`}`), "tool", nil)
+		}(i)
+	}
+	wg.Wait()
+
+	if sc.Len() != n {
+		t.Errorf("Len = %d, want %d", sc.Len(), n)
+	}
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			prompt := fmt.Sprintf("prompt-%d", id)
+			result, _ := sc.Get(ctx, prompt, "tool", nil)
+			if result.HitType != HitExact {
+				t.Errorf("prompt-%d: expected hit, got %v", id, result.HitType)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := sc.Stats().ExactHits; got != int64(n) {
+		t.Errorf("ExactHits = %d, want %d", got, n)
+	}
+}
+
+func TestSemanticCache_StartStopLifecycle(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, time.Hour,
+		WithEvictionInterval(10*time.Millisecond),
+		WithStatsPersistPath(""),
+	)
+
+	sc.Start(context.Background())
+	sc.Start(context.Background()) // double-start must be a no-op
+
+	done := make(chan struct{})
+	go func() {
+		sc.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return promptly — evict loop not responding to shutdown")
+	}
+
+	sc.Stop() // double-stop must be a no-op
+}
+
+func TestSemanticCache_EvictExpired(t *testing.T) {
+	sc := NewSemanticCache(nil, nil, 50*time.Millisecond)
+	ctx := context.Background()
+
+	sc.Set(ctx, "old-entry", json.RawMessage(`{"r":1}`), "tool", nil)
+	sc.Set(ctx, "another-old", json.RawMessage(`{"r":2}`), "tool", nil)
+
+	time.Sleep(60 * time.Millisecond)
+
+	sc.Set(ctx, "fresh-entry", json.RawMessage(`{"r":3}`), "tool", nil)
+
+	sc.evictExpired()
+
+	if sc.Len() != 1 {
+		t.Errorf("Len after eviction = %d, want 1 (only fresh)", sc.Len())
+	}
+
+	if got := sc.Stats().EvictedEntries; got != 2 {
+		t.Errorf("EvictedEntries = %d, want exactly 2", got)
+	}
+}
+
+func TestHitType_String(t *testing.T) {
+	cases := map[HitType]string{
+		HitMiss:     "miss",
+		HitExact:    "exact",
+		HitSemantic: "semantic",
+		HitType(99): "miss",
+	}
+	for ht, want := range cases {
+		if got := ht.String(); got != want {
+			t.Errorf("HitType(%d).String() = %q, want %q", int(ht), got, want)
+		}
+	}
+}
+
+func TestSemanticCacheStats_HitRate(t *testing.T) {
+	s := SemanticCacheStats{}
+	if s.HitRate() != 0.0 {
+		t.Errorf("HitRate with no requests = %.2f, want 0", s.HitRate())
+	}
+	s = SemanticCacheStats{TotalRequests: 10, ExactHits: 5, SemanticHits: 2}
+	if got := s.HitRate(); got != 70.0 {
+		t.Errorf("HitRate = %.2f, want 70.00", got)
+	}
+}
+
+func TestSemanticCacheStats_FormatMarkdown(t *testing.T) {
+	stats := SemanticCacheStats{
+		TotalRequests:  100,
+		ExactHits:      50,
+		SemanticHits:   30,
+		Misses:         20,
+		AvgSimilarity:  0.95,
+		EvictedEntries: 5,
+	}
+
+	md := stats.FormatMarkdown()
+	for _, want := range []string{"Total Requests", "80.00%", "Avg Similarity", "0.950", "Evicted Entries"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("Markdown missing %q:\n%s", want, md)
+		}
+	}
+
+	// Avg Similarity row must always be present, even with zero semantic hits.
+	empty := SemanticCacheStats{TotalRequests: 4, Misses: 4}
+	if !strings.Contains(empty.FormatMarkdown(), "Avg Similarity") {
+		t.Error("Avg Similarity row must be emitted even when SemanticHits == 0")
+	}
+}
+
+func TestSemanticCacheStats_FormatJSON(t *testing.T) {
+	stats := SemanticCacheStats{TotalRequests: 10, ExactHits: 5}
+
+	jsonStr := stats.FormatJSON()
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if parsed["total_requests"] != float64(10) {
+		t.Errorf("total_requests = %v, want 10", parsed["total_requests"])
+	}
+}
+
+func TestGlobalSemanticCache(t *testing.T) {
+	prev := GlobalSemanticCache()
+	t.Cleanup(func() { SetGlobalSemanticCache(prev) })
+
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	SetGlobalSemanticCache(sc)
+
+	if got := GlobalSemanticCache(); got != sc {
+		t.Error("GlobalSemanticCache should return the same instance")
+	}
+}
+
+func BenchmarkSemanticCacheGetExact(b *testing.B) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	ctx := context.Background()
+	sc.Set(ctx, "bench prompt", json.RawMessage(`{"result":"ok"}`), "tool", nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sc.Get(ctx, "bench prompt", "tool", nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSemanticCacheSet(b *testing.B) {
+	sc := NewSemanticCache(nil, nil, time.Hour)
+	ctx := context.Background()
+	resp := json.RawMessage(`{"result":"ok"}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := sc.Set(ctx, "bench prompt", resp, "tool", nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/cache/semantic_persist.go
+++ b/pkg/cache/semantic_persist.go
@@ -1,0 +1,91 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/utils"
+)
+
+const semanticStatsVersion = 1
+
+// SemanticStatsSnapshot is the on-disk representation of semantic cache
+// statistics, written periodically by the running server so that separate
+// CLI processes can render the dashboard.
+type SemanticStatsSnapshot struct {
+	Version   int                `json:"version"`
+	UpdatedAt time.Time          `json:"updated_at"`
+	Stats     SemanticCacheStats `json:"stats"`
+}
+
+// DefaultSemanticStatsPath returns the stats file location used by both the
+// server (writer) and the CLI (reader): ~/.leanproxy/cache/semantic-stats.json
+func DefaultSemanticStatsPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "leanproxy", "cache", "semantic-stats.json")
+	}
+	return filepath.Join(home, ".leanproxy", "cache", "semantic-stats.json")
+}
+
+// persistStats writes the current stats snapshot atomically (tmp + rename).
+// Failures are logged but never propagated: persistence is best-effort.
+func (sc *SemanticCache) persistStats() {
+	if sc.persistPath == "" {
+		return
+	}
+	snap := SemanticStatsSnapshot{
+		Version:   semanticStatsVersion,
+		UpdatedAt: time.Now(),
+		Stats:     sc.Stats(),
+	}
+	if err := writeSemanticStatsSnapshot(sc.persistPath, snap); err != nil {
+		sc.logger.Warn("semantic cache: stats persist failed", "path", sc.persistPath, "error", err)
+	}
+}
+
+func writeSemanticStatsSnapshot(path string, snap SemanticStatsSnapshot) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create stats dir: %w", err)
+	}
+	if err := utils.ValidatePath(path, filepath.Dir(filepath.Clean(path))); err != nil {
+		return fmt.Errorf("invalid stats path: %w", err)
+	}
+
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal stats: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
+		return fmt.Errorf("write temp stats: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("atomic rename: %w", err)
+	}
+	return nil
+}
+
+// LoadSemanticStatsSnapshot reads a stats snapshot written by the server.
+// A missing file is reported as an error so callers can render an
+// "unavailable" message.
+func LoadSemanticStatsSnapshot(path string) (*SemanticStatsSnapshot, error) {
+	if err := utils.ValidatePath(path, filepath.Dir(filepath.Clean(path))); err != nil {
+		return nil, fmt.Errorf("invalid stats path: %w", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read stats: %w", err)
+	}
+	var snap SemanticStatsSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, fmt.Errorf("parse stats: %w", err)
+	}
+	return &snap, nil
+}

--- a/pkg/cache/semantic_persist_test.go
+++ b/pkg/cache/semantic_persist_test.go
@@ -1,0 +1,68 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSemanticStatsSnapshot_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stats", "semantic-stats.json")
+
+	sc := NewSemanticCache(nil, nil, time.Hour, WithStatsPersistPath(path))
+	sc.Set(t.Context(), "p", []byte(`{"r":1}`), "tool", nil)
+	sc.Get(t.Context(), "p", "tool", nil)
+
+	sc.persistStats()
+
+	snap, err := LoadSemanticStatsSnapshot(path)
+	if err != nil {
+		t.Fatalf("LoadSemanticStatsSnapshot failed: %v", err)
+	}
+	if snap.Version != semanticStatsVersion {
+		t.Errorf("Version = %d, want %d", snap.Version, semanticStatsVersion)
+	}
+	if snap.Stats.TotalRequests != 1 {
+		t.Errorf("TotalRequests = %d, want 1", snap.Stats.TotalRequests)
+	}
+	if snap.Stats.ExactHits != 1 {
+		t.Errorf("ExactHits = %d, want 1", snap.Stats.ExactHits)
+	}
+	if snap.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt must be set")
+	}
+}
+
+func TestLoadSemanticStatsSnapshot_MissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.json")
+	if _, err := LoadSemanticStatsSnapshot(path); err == nil {
+		t.Error("expected error for missing stats file")
+	}
+}
+
+func TestSemanticCache_StopPersistsFinalSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "semantic-stats.json")
+
+	sc := NewSemanticCache(nil, nil, time.Hour,
+		WithStatsPersistPath(path),
+		WithStatsPersistInterval(time.Hour), // ensure only Stop writes
+	)
+	sc.Start(t.Context())
+	sc.Set(t.Context(), "p", []byte(`{"r":1}`), "tool", nil)
+	sc.Get(t.Context(), "p", "tool", nil)
+	sc.Stop()
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Stop() must write a final stats snapshot: %v", err)
+	}
+	snap, err := LoadSemanticStatsSnapshot(path)
+	if err != nil {
+		t.Fatalf("load after Stop failed: %v", err)
+	}
+	if snap.Stats.TotalRequests != 1 {
+		t.Errorf("TotalRequests = %d, want 1", snap.Stats.TotalRequests)
+	}
+}

--- a/pkg/registry/feed.go
+++ b/pkg/registry/feed.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -54,6 +56,12 @@ type FeedFetcher struct {
 	cached   *FeedIndex
 
 	refreshWG sync.WaitGroup
+
+	onSync func(entries []RegistryFeedEntry)
+}
+
+func (f *FeedFetcher) OnSync(fn func(entries []RegistryFeedEntry)) {
+	f.onSync = fn
 }
 
 func NewFeedFetcher(logger *slog.Logger, cacheDir string) *FeedFetcher {
@@ -134,6 +142,15 @@ func (f *FeedFetcher) Sync(ctx context.Context) error {
 		Entries:  entries,
 	}
 
+	// Detect whether the feed content actually changed since the last sync
+	// so downstream invalidation hooks only fire on real changes.
+	changed := true
+	if prev, err := f.readCacheFromDisk(); err == nil && prev != nil {
+		if hashFeedEntries(prev.Entries) == hashFeedEntries(entries) {
+			changed = false
+		}
+	}
+
 	if err := f.store(index); err != nil {
 		return fmt.Errorf("registry feed: store cache: %w", err)
 	}
@@ -147,7 +164,36 @@ func (f *FeedFetcher) Sync(ctx context.Context) error {
 		"entries", len(entries),
 		"cache", f.IndexPath(),
 	)
+
+	if f.onSync != nil && changed {
+		f.invokeOnSync(entries)
+	} else if !changed {
+		f.logger.Debug("registry feed unchanged, skipping onSync hook")
+	}
+
 	return nil
+}
+
+// invokeOnSync runs the registered callback with panic isolation so a faulty
+// hook cannot crash the process.
+func (f *FeedFetcher) invokeOnSync(entries []RegistryFeedEntry) {
+	defer func() {
+		if r := recover(); r != nil {
+			f.logger.Error("registry feed: onSync callback panicked", "panic", r)
+		}
+	}()
+	f.onSync(entries)
+}
+
+// hashFeedEntries returns a stable hash of the entry list for change
+// detection between syncs.
+func hashFeedEntries(entries []RegistryFeedEntry) string {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 func (f *FeedFetcher) store(index FeedIndex) error {

--- a/pkg/registry/feed_test.go
+++ b/pkg/registry/feed_test.go
@@ -427,3 +427,91 @@ func newTestRegistryServer(t *testing.T, entries []RegistryFeedEntry) *httptest.
 		}
 	}))
 }
+
+// mutableRegistryServer serves NDJSON whose content can be swapped between
+// requests, enabling change-detection tests.
+type mutableRegistryServer struct {
+	mu      sync.Mutex
+	entries []RegistryFeedEntry
+	ts      *httptest.Server
+}
+
+func newMutableRegistryServer(t *testing.T, entries []RegistryFeedEntry) *mutableRegistryServer {
+	t.Helper()
+	m := &mutableRegistryServer{entries: entries}
+	m.ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		for _, entry := range m.entries {
+			data, err := json.Marshal(entry)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprintln(w, string(data))
+		}
+	}))
+	t.Cleanup(m.ts.Close)
+	return m
+}
+
+func (m *mutableRegistryServer) setEntries(entries []RegistryFeedEntry) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = entries
+}
+
+func TestFeedFetcher_OnSync_FiresOnlyOnChange(t *testing.T) {
+	cacheDir := t.TempDir()
+	fetcher := NewFeedFetcher(nil, cacheDir)
+
+	initial := []RegistryFeedEntry{
+		{Name: "github", Description: "GitHub API", Transport: "stdio"},
+	}
+	srv := newMutableRegistryServer(t, initial)
+	fetcher.WithURL(srv.ts.URL)
+
+	var calls int
+	fetcher.OnSync(func(entries []RegistryFeedEntry) { calls++ })
+
+	ctx := context.Background()
+
+	if err := fetcher.Sync(ctx); err != nil {
+		t.Fatalf("first Sync() failed: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("OnSync calls after first sync = %d, want 1 (no prior cache)", calls)
+	}
+
+	if err := fetcher.Sync(ctx); err != nil {
+		t.Fatalf("second Sync() failed: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("OnSync calls after identical sync = %d, want 1 (unchanged content must not fire)", calls)
+	}
+
+	srv.setEntries([]RegistryFeedEntry{
+		{Name: "github", Description: "GitHub API v2", Transport: "stdio"},
+		{Name: "slack", Description: "Slack API", Transport: "http"},
+	})
+	if err := fetcher.Sync(ctx); err != nil {
+		t.Fatalf("third Sync() failed: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("OnSync calls after changed sync = %d, want 2", calls)
+	}
+}
+
+func TestFeedFetcher_OnSync_PanicIsRecovered(t *testing.T) {
+	cacheDir := t.TempDir()
+	fetcher := NewFeedFetcher(nil, cacheDir)
+
+	srv := newMutableRegistryServer(t, []RegistryFeedEntry{{Name: "x"}})
+	fetcher.WithURL(srv.ts.URL)
+
+	fetcher.OnSync(func(entries []RegistryFeedEntry) { panic("boom") })
+
+	if err := fetcher.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync() must succeed despite panicking callback: %v", err)
+	}
+}


### PR DESCRIPTION
# Story 12.3 — Semantic Cache: TTL, Invalidation, and Hit/Miss Dashboard

**Epic:** 12 — Semantic Prompt Cache · **FR:** FR42 · **NFR:** NFR9
**Story file:** `_bmad-output/implementation-artifacts/12-3-cache-ttl-dashboard.md` (status: `done`)

## Summary

Delivers the semantic prompt cache's correctness and observability layer: entries expire on a 24h TTL, registry changes invalidate cached entries, and a `leanproxy cache --semantic` dashboard reports hit/miss statistics. The cache is fully wired into the proxy request path — every tool call flowing through `serve` is looked up (exact match first, then vector similarity) and fresh responses are written back.

This PR also incorporates the complete adversarial code-review cycle: **3 review layers, 25 raw findings, 21 triaged fixes — all applied.** (4 dismissed as noise.)

## Acceptance Criteria

| AC | Status | Implementation |
|----|--------|----------------|
| Entry > TTL (default 24h) → miss, write fresh after response | ✅ | TTL checked on every hit path + hourly background eviction; `semanticCacheStore` writes fresh responses in all 4 proxy handlers |
| Tool schema change (registry refresh) → purge entries + log count | ✅ | `FeedFetcher.OnSync` fires **only on real feed changes** (SHA-256 of entries) → `PurgeAll()` with logged count |
| `leanproxy cache --semantic` → table: total, exact hits, semantic hits, misses, hit rate %, avg similarity | ✅ | Stats persisted to `~/.leanproxy/cache/semantic-stats.json` (30s interval + on shutdown); CLI renders all six fields from the snapshot (Markdown or `--json`) |
| Cache hit → log `cache=semantic similarity=X` to stderr, increment counter | ✅ | Exact: `similarity=1.000`; semantic: `similarity=<score>` via `fmt.Sprintf` (slog does not interpolate printf verbs — caught in review); counters on both paths |

## What's in the box

### `pkg/cache/semantic_cache.go` (new, ~460 lines)
- **Tool-scoped keys** — `sha256(toolName + "\x00" + prompt)`; identical prompts to different tools can never share an entry, and cross-tool semantic candidates are rejected post-search (review finding: cross-tool poisoning).
- **Exact + semantic lookup** — O(1) exact path (~1.06µs/op benchmarked); vector fallback via `vectordb.Store` with 0.92 similarity threshold, top-5 candidates scanned for first valid same-tool entry.
- **TTL eviction** — inline expiry on access (counted in stats) + hourly background sweep.
- **Lifecycle** — idempotent `Start(ctx)`; `Stop()` responds immediately (done-channel, not ticker-bound), waits for tracked background deletes, writes a final stats snapshot. Wired into SIGINT/SIGTERM **before** vector-store `Close()` so async deletes never race a closed store.
- **Context-aware I/O** — `Get`/`Set` take `ctx`; all background deletes bounded to 10s.
- **Cache-aside contract** — degraded vector store ⇒ exact-match-only; lookups never fail the request.

### `pkg/cache/semantic_persist.go` (new)
- Atomic snapshot writes (tmp + rename, 0600/0700, path-validated) so the separate CLI process can render the dashboard (review finding: process-local singleton made AC3 unreachable).

### `cmd/serve.go` (modified)
- `semanticCacheLookup`/`semanticCacheStore` wired into `handleSingleRequest`, `handleSingleRequestAsync`, and both batch handlers.
- Embeddings fetched synchronously from the embedder pool with a **2s timeout** — cache never stalls requests on a sick provider.
- JSON-RPC lifecycle/listing methods denylisted (`initialize`, `ping`, `tools/list`, …).

### `pkg/registry/feed.go` (modified)
- `OnSync(entries)` hook: fires only when the feed's SHA-256 differs from the previous sync (review finding: unconditional hourly `PurgeAll` capped effective TTL at 1h), and panic-isolated via `recover`.

### `cmd/cache.go` (modified)
- `--semantic` dashboard reads the persisted snapshot (works whenever the server has written stats); snapshot timestamp shown.
- `--json` emits valid JSON in **every** branch, including stats-unavailable.
- `--semantic` marked mutually exclusive with `--clear`/`--list`/`--search`/`--location`/`--server`.

## Code review (bmad-code-review, 3 parallel layers)

| Layer | Focus | Findings |
|-------|-------|----------|
| Blind Hunter | adversarial correctness/concurrency | cross-tool poisoning, dead dashboard, unwired cache, Stop-hang, slog format bug, TOCTOU, … |
| Edge Case Hunter | boundary/branch coverage | panic-kills-process, JSON breakage, flag precedence, mock contract, … |
| Acceptance Auditor | AC/spec compliance | AC1 "write fresh" unimplemented, AC3 dashboard unreachable, AC4 literal `%.3f`, missing benchmark |

**Triage:** 3 `decision-needed` (user resolved: wire now / persist-to-file / purge-on-real-change), 18 `patch` (all applied), 4 dismissed (write-lock perf on unwired code, OnSync setter semantics, 0.92-boundary, lifecycle-after-Stop acceptance). Full detail in the story file's *Review Findings* section.

## Testing

- **1,431 tests passing** across 26 packages (`go test ./...`), incl. **35 new**:
  - cache: cross-tool isolation (exact + semantic), TTL/lazy-eviction accounting, Start/Stop promptness (2s assertion), double-start/stop, thread safety, snapshot round-trip, Stop-persists-final
  - registry: `OnSync` fires on first sync, **not** on identical re-sync, fires on change; panicking callback recovered
  - cmd: `--semantic` markdown contains all six fields; `--json` valid with data and when unavailable
- **Benchmarks:** `BenchmarkSemanticCacheGetExact` ≈ **1.06µs/op**, `BenchmarkSemanticCacheSet` (story target: <1ms p95)
- `go vet ./...` clean · `go test -race ./pkg/cache/` clean
