### PR TITLE
Story 14-1: Publish /metrics JSON endpoint

### DIFF
--- a/_bmad-output/implementation-artifacts/14-1-metrics-endpoint.md
+++ b/_bmad-output/implementation-artifacts/14-1-metrics-endpoint.md
@@ -1,6 +1,10 @@
+---
+baseline_commit: fc54f8391d5c0db2e01914ae9ddeadfc8c38dadd
+---
+
 # Story 14.1: Publish /metrics JSON endpoint
 
-Status: ready-for-dev
+Status: done
 
 ## Story Header
 
@@ -51,6 +55,50 @@ New files listed in technical notes; modify existing files only where required.
 - [Source: _bmad-output/brainstorming/brainstorming-session-2026-05-01.md] (original market-trend idea)
 - Related epic: IDE Plugin (VS Code / JetBrains) + Live Cost Sidebar
 
+## Tasks/Subtasks
+
+- [x] Create `pkg/metrics/aggregator.go` — MetricsSnapshot struct + Snapshot() function wrapping reporter.CostTracker
+- [x] Create `pkg/metrics/server.go` — HTTP server for /metrics endpoint using net/http stdlib
+- [x] Write unit tests for aggregator (Snapshot, empty data, top-5 sorting, concurrency)
+- [x] Write integration tests for server (disabled addr, GET /metrics response, method validation, concurrent requests)
+- [x] Integrate metrics server into `cmd/serve.go` — add `--metrics-bind` flag, start/shutdown lifecycle
+- [x] Run full test suite and verify no regressions (1584 tests passing)
+- [x] Update story file with status, file list, and completion notes
+
+## Dev Agent Record
+
+### Debug Log
+
+- Implemented metrics package at `pkg/metrics/` with aggregator and HTTP server components
+- Reused existing `reporter.GlobalCostTracker()` for token tracking — no duplicate state
+- Integrated into `cmd/serve.go` with `--metrics-bind` flag; empty or "off" disables the endpoint
+- Used `net.Listen` + `srv.Serve` pattern to correctly report the actual listening port
+- Non-loopback bind addresses produce a security warning via slog.Warn (per FR44 security requirement)
+- No new dependencies introduced; all functionality uses stdlib (`net/http`, `encoding/json`)
+
+### Completion Notes
+
+Implemented `/metrics` JSON endpoint exposing real-time token spend data. The server starts on the main serve lifecycle, respects disable-by-config, warns on non-loopback bind, and exposes per-server tokens, per-tool tokens, total session spend, and top-5 most expensive tools. All 1584 tests pass with no regressions.
+
 ## File List
 
-- See Technical Notes above
+- `pkg/metrics/aggregator.go` (NEW)
+- `pkg/metrics/server.go` (NEW)
+- `pkg/metrics/aggregator_test.go` (NEW)
+- `pkg/metrics/server_test.go` (NEW)
+- `cmd/serve.go` (MODIFIED — added metrics integration)
+
+## Review Findings
+
+- [x] [Review][Patch] `enc.Encode(snapshot)` error silently discarded [pkg/metrics/server.go:64]
+- [x] [Review][Patch] Empty host (`:9090`) binds all interfaces without security warning [pkg/metrics/server.go:22]
+- [x] [Review][Patch] Test cleanup lacks `defer` for `Reset()`, risks state leaks on panic [pkg/metrics/aggregator_test.go]
+- [x] [Review][Patch] `TestServeConcurrentRequests` silently discards HTTP errors [pkg/metrics/server_test.go:125-134]
+- [x] [Review][Patch] Fragile test name generation using `string(rune('a' + i - 1))` [pkg/metrics/aggregator_test.go:67]
+- [x] [Review][Defer] No graceful shutdown (`Close()` vs `Shutdown()`) — pre-existing pattern across codebase [cmd/serve.go:319]
+- [x] [Review][Defer] Redundant allocation in `Snapshot()` — metrics endpoint is not a hot path [pkg/metrics/aggregator.go]
+
+## Change Log
+
+- Added `pkg/metrics/` package with aggregator and HTTP server for /metrics endpoint
+- Modified `cmd/serve.go` to accept `--metrics-bind` flag and manage metrics server lifecycle

--- a/_bmad-output/implementation-artifacts/loop-status.yaml
+++ b/_bmad-output/implementation-artifacts/loop-status.yaml
@@ -3,7 +3,8 @@ started: "2026-07-19"
 total_stories: 3
 stories:
   - key: "14-1"
-    status: pr-in-progress
+    status: ci-in-progress
+    pr_number: 252
   - key: "14-2"
     status: pending
   - key: "14-3"

--- a/_bmad-output/implementation-artifacts/loop-status.yaml
+++ b/_bmad-output/implementation-artifacts/loop-status.yaml
@@ -1,13 +1,10 @@
 # Loop Status
-started: "2026-07-18"
+started: "2026-07-19"
 total_stories: 3
 stories:
-  - key: "13-1"
-    status: merged
-    pr_number: 249
-  - key: "13-2"
-    status: merged
-    pr_number: 250
-  - key: "13-3"
-    status: merged
-    pr_number: 251
+  - key: "14-1"
+    status: pr-in-progress
+  - key: "14-2"
+    status: pending
+  - key: "14-3"
+    status: pending

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -91,7 +91,7 @@ development_status:
   13-1-injection-classifier: done
   13-2-configurable-actions: done
   13-3-red-team-corpus: done
-  14-1-metrics-endpoint: ready-for-dev
+  14-1-metrics-endpoint: done
   14-2-vscode-extension: ready-for-dev
   14-3-jetbrains-plugin: ready-for-dev
   15-1-per-tool-model-routing: ready-for-dev

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"os/user"
@@ -25,6 +26,7 @@ import (
 	"github.com/mmornati/leanproxy-mcp/pkg/errors"
 	"github.com/mmornati/leanproxy-mcp/pkg/gateway"
 	"github.com/mmornati/leanproxy-mcp/pkg/mcp"
+	"github.com/mmornati/leanproxy-mcp/pkg/metrics"
 	"github.com/mmornati/leanproxy-mcp/pkg/migrate"
 	"github.com/mmornati/leanproxy-mcp/pkg/pool"
 	"github.com/mmornati/leanproxy-mcp/pkg/proxy"
@@ -53,7 +55,10 @@ var serveFlags struct {
 	ollamaModel     string
 	openAIModel     string
 	embedPoolSize   int
+	metricsBind     string
 }
+
+var metricsServer *http.Server
 
 var providerDetector atomic.Pointer[cache.ProviderDetector]
 var breakpointInjector atomic.Pointer[cache.BreakpointInjector]
@@ -95,6 +100,7 @@ func init() {
 	serveCmd.Flags().StringVar(&serveFlags.ollamaModel, "ollama-model", "nomic-embed-text", "Ollama embedding model")
 	serveCmd.Flags().StringVar(&serveFlags.openAIModel, "openai-model", "text-embedding-3-small", "OpenAI embedding model")
 	serveCmd.Flags().IntVar(&serveFlags.embedPoolSize, "embed-pool-size", 4, "Embedder worker pool size")
+	serveCmd.Flags().StringVar(&serveFlags.metricsBind, "metrics-bind", "", "Metrics endpoint bind address (e.g. 127.0.0.1:9090). Set to 'off' or empty to disable.")
 	RootCmd.AddCommand(serveCmd)
 }
 
@@ -262,6 +268,11 @@ func runServe(cmd *cobra.Command, args []string) {
 		go updateServerStatusPeriodically()
 	}
 
+	metricsServer, err = metrics.ListenAndServe(serveFlags.metricsBind, slog.Default())
+	if err != nil {
+		slog.Warn("failed to start metrics endpoint", "error", err)
+	}
+
 	go startRegistryFeedSync(ctx, func(entries []registry.RegistryFeedEntry) {
 		if sc := cache.GlobalSemanticCache(); sc != nil {
 			count := sc.PurgeAll()
@@ -305,6 +316,9 @@ func runServe(cmd *cobra.Command, args []string) {
 				}
 				slog.Info("shutting down server")
 				signal.Stop(sigChan)
+				if metricsServer != nil {
+					metricsServer.Close()
+				}
 				if statusStore != nil {
 					statusStore.RemoveFile()
 				}

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"sort"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/reporter"
+)
+
+type MetricsSnapshot struct {
+	ByTool             []ToolMetric  `json:"by_tool"`
+	ByServer           []ServerMetric `json:"by_server"`
+	TotalSpend         int64         `json:"total_spend"`
+	Top5ExpensiveTools []ToolMetric  `json:"top_5_expensive_tools"`
+}
+
+type ToolMetric struct {
+	ToolName   string `json:"tool_name"`
+	TokenCount int64  `json:"token_count"`
+}
+
+type ServerMetric struct {
+	ServerName string `json:"server_name"`
+	TokenCount int64  `json:"token_count"`
+}
+
+func Snapshot() MetricsSnapshot {
+	tracker := reporter.GlobalCostTracker()
+	breakdown := tracker.GetBreakdown()
+
+	byTool := make([]ToolMetric, len(breakdown.ByTool))
+	for i, tc := range breakdown.ByTool {
+		byTool[i] = ToolMetric{ToolName: tc.ToolName, TokenCount: tc.TokenCount}
+	}
+
+	byServer := make([]ServerMetric, len(breakdown.ByServer))
+	for i, sc := range breakdown.ByServer {
+		byServer[i] = ServerMetric{ServerName: sc.ServerName, TokenCount: sc.TokenCount}
+	}
+
+	top5 := make([]ToolMetric, 0, len(byTool))
+	top5 = append(top5, byTool...)
+	sort.Slice(top5, func(i, j int) bool {
+		return top5[i].TokenCount > top5[j].TokenCount
+	})
+	if len(top5) > 5 {
+		top5 = top5[:5]
+	}
+
+	return MetricsSnapshot{
+		ByTool:             byTool,
+		ByServer:           byServer,
+		TotalSpend:         breakdown.Total,
+		Top5ExpensiveTools: top5,
+	}
+}

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -7,10 +7,10 @@ import (
 )
 
 type MetricsSnapshot struct {
-	ByTool             []ToolMetric  `json:"by_tool"`
+	ByTool             []ToolMetric   `json:"by_tool"`
 	ByServer           []ServerMetric `json:"by_server"`
-	TotalSpend         int64         `json:"total_spend"`
-	Top5ExpensiveTools []ToolMetric  `json:"top_5_expensive_tools"`
+	TotalSpend         int64          `json:"total_spend"`
+	Top5ExpensiveTools []ToolMetric   `json:"top_5_expensive_tools"`
 }
 
 type ToolMetric struct {

--- a/pkg/metrics/aggregator_test.go
+++ b/pkg/metrics/aggregator_test.go
@@ -1,0 +1,102 @@
+package metrics
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/reporter"
+)
+
+func TestSnapshot(t *testing.T) {
+	reporter.GlobalCostTracker().Reset()
+	t.Cleanup(func() { reporter.GlobalCostTracker().Reset() })
+
+	reporter.TrackCost("tool-a", "server-1", 100)
+	reporter.TrackCost("tool-b", "server-1", 200)
+	reporter.TrackCost("tool-c", "server-2", 50)
+
+	snap := Snapshot()
+
+	if snap.TotalSpend != 350 {
+		t.Errorf("TotalSpend = %d, want 350", snap.TotalSpend)
+	}
+
+	if len(snap.ByTool) != 3 {
+		t.Errorf("len(ByTool) = %d, want 3", len(snap.ByTool))
+	}
+
+	if len(snap.ByServer) != 2 {
+		t.Errorf("len(ByServer) = %d, want 2", len(snap.ByServer))
+	}
+
+	if len(snap.Top5ExpensiveTools) != 3 {
+		t.Errorf("len(Top5ExpensiveTools) = %d, want 3 (only 3 tools tracked)", len(snap.Top5ExpensiveTools))
+	}
+
+	if snap.Top5ExpensiveTools[0].ToolName != "tool-b" {
+		t.Errorf("top1 tool = %s, want tool-b", snap.Top5ExpensiveTools[0].ToolName)
+	}
+}
+
+func TestSnapshotEmpty(t *testing.T) {
+	reporter.GlobalCostTracker().Reset()
+	t.Cleanup(func() { reporter.GlobalCostTracker().Reset() })
+
+	snap := Snapshot()
+
+	if snap.TotalSpend != 0 {
+		t.Errorf("TotalSpend = %d, want 0", snap.TotalSpend)
+	}
+	if len(snap.ByTool) != 0 {
+		t.Errorf("len(ByTool) = %d, want 0", len(snap.ByTool))
+	}
+	if len(snap.ByServer) != 0 {
+		t.Errorf("len(ByServer) = %d, want 0", len(snap.ByServer))
+	}
+	if len(snap.Top5ExpensiveTools) != 0 {
+		t.Errorf("len(Top5ExpensiveTools) = %d, want 0", len(snap.Top5ExpensiveTools))
+	}
+}
+
+func TestSnapshotTop5(t *testing.T) {
+	reporter.GlobalCostTracker().Reset()
+	t.Cleanup(func() { reporter.GlobalCostTracker().Reset() })
+
+	toolNames := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+	for i, name := range toolNames {
+		reporter.TrackCost("tool-"+name, "server-1", int64((i+1)*100))
+	}
+
+	snap := Snapshot()
+
+	if len(snap.Top5ExpensiveTools) != 5 {
+		t.Errorf("len(Top5ExpensiveTools) = %d, want 5", len(snap.Top5ExpensiveTools))
+	}
+
+	if snap.Top5ExpensiveTools[0].TokenCount != 1000 {
+		t.Errorf("top1 tokens = %d, want 1000", snap.Top5ExpensiveTools[0].TokenCount)
+	}
+	if snap.Top5ExpensiveTools[4].TokenCount != 600 {
+		t.Errorf("top5 tokens = %d, want 600", snap.Top5ExpensiveTools[4].TokenCount)
+	}
+}
+
+func TestSnapshotConcurrency(t *testing.T) {
+	reporter.GlobalCostTracker().Reset()
+	t.Cleanup(func() { reporter.GlobalCostTracker().Reset() })
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			reporter.TrackCost("tool", "server", int64(n))
+		}(i)
+	}
+	wg.Wait()
+
+	snap := Snapshot()
+	if snap.TotalSpend == 0 {
+		t.Error("expected non-zero total after concurrent tracking")
+	}
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+func ListenAndServe(addr string, logger *slog.Logger) (*http.Server, error) {
+	if addr == "" || addr == "off" {
+		logger.Info("metrics endpoint disabled")
+		return nil, nil
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if host == "" || (host != "127.0.0.1" && host != "localhost" && host != "::1") {
+		logger.Warn("metrics endpoint listening on non-loopback interface; data is not encrypted",
+			"bind", addr)
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics", handleMetrics)
+
+	srv := &http.Server{
+		Addr:    ln.Addr().String(),
+		Handler: mux,
+	}
+
+	go func() {
+		logger.Info("metrics endpoint started", "bind", srv.Addr)
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			logger.Error("metrics endpoint error", "error", err)
+		}
+	}()
+
+	return srv, nil
+}
+
+func handleMetrics(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	snapshot := Snapshot()
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		enc.SetIndent("", "")
+	}
+	if err := enc.Encode(snapshot); err != nil {
+		slog.Error("failed to encode metrics snapshot", "error", err)
+	}
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 )
 
 func ListenAndServe(addr string, logger *slog.Logger) (*http.Server, error) {
@@ -33,8 +34,9 @@ func ListenAndServe(addr string, logger *slog.Logger) (*http.Server, error) {
 	mux.HandleFunc("/metrics", handleMetrics)
 
 	srv := &http.Server{
-		Addr:    ln.Addr().String(),
-		Handler: mux,
+		Addr:              ln.Addr().String(),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	go func() {

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -1,0 +1,150 @@
+package metrics
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/mmornati/leanproxy-mcp/pkg/reporter"
+)
+
+func TestListenAndServeDisabled(t *testing.T) {
+	srv, err := ListenAndServe("", slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error for empty addr: %v", err)
+	}
+	if srv != nil {
+		t.Error("expected nil server for empty addr")
+	}
+
+	srv, err = ListenAndServe("off", slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error for 'off' addr: %v", err)
+	}
+	if srv != nil {
+		t.Error("expected nil server for 'off' addr")
+	}
+}
+
+func TestListenAndServeMetricsEndpoint(t *testing.T) {
+	reporter.GlobalCostTracker().Reset()
+	defer reporter.GlobalCostTracker().Reset()
+
+	reporter.TrackCost("test-tool", "test-server", 500)
+
+	srv, err := ListenAndServe("127.0.0.1:0", slog.Default())
+	if err != nil {
+		t.Fatalf("ListenAndServe failed: %v", err)
+	}
+	if srv == nil {
+		t.Fatal("expected non-nil server")
+	}
+	defer srv.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	addr := srv.Addr
+	resp, err := http.Get("http://" + addr + "/metrics")
+	if err != nil {
+		t.Fatalf("GET /metrics failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var snap MetricsSnapshot
+	if err := json.Unmarshal(body, &snap); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if snap.TotalSpend != 500 {
+		t.Errorf("TotalSpend = %d, want 500", snap.TotalSpend)
+	}
+	if len(snap.ByServer) != 1 || snap.ByServer[0].ServerName != "test-server" {
+		t.Errorf("ByServer: %+v", snap.ByServer)
+	}
+	if len(snap.ByTool) != 1 || snap.ByTool[0].ToolName != "test-tool" {
+		t.Errorf("ByTool: %+v", snap.ByTool)
+	}
+}
+
+func TestMetricsEndpointMethodNotAllowed(t *testing.T) {
+	reporter.GlobalCostTracker().Reset()
+	defer reporter.GlobalCostTracker().Reset()
+
+	srv, err := ListenAndServe("127.0.0.1:0", slog.Default())
+	if err != nil {
+		t.Fatalf("ListenAndServe failed: %v", err)
+	}
+	defer srv.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Post("http://"+srv.Addr+"/metrics", "text/plain", nil)
+	if err != nil {
+		t.Fatalf("POST /metrics failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestListenAndServeInvalidAddr(t *testing.T) {
+	_, err := ListenAndServe("not-a-valid-addr", slog.Default())
+	if err == nil {
+		t.Error("expected error for invalid address")
+	}
+}
+
+func TestServeConcurrentRequests(t *testing.T) {
+	reporter.GlobalCostTracker().Reset()
+	defer reporter.GlobalCostTracker().Reset()
+
+	reporter.TrackCost("tool-x", "server-x", 999)
+
+	srv, err := ListenAndServe("127.0.0.1:0", slog.Default())
+	if err != nil {
+		t.Fatalf("ListenAndServe failed: %v", err)
+	}
+	defer srv.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	type result struct {
+		status int
+		err    error
+	}
+	results := make(chan result, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			resp, err := http.Get("http://" + srv.Addr + "/metrics")
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			resp.Body.Close()
+			results <- result{status: resp.StatusCode}
+		}()
+	}
+
+	for i := 0; i < 10; i++ {
+		r := <-results
+		if r.err != nil {
+			t.Errorf("concurrent request %d failed: %v", i, r.err)
+		} else if r.status != http.StatusOK {
+			t.Errorf("concurrent request %d status = %d, want 200", i, r.status)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Created a /metrics JSON endpoint in a new pkg/metrics/ package that exposes real-time token spend data (per-server, per-tool, total, top-5 tools) by wrapping the existing reporter.CostTracker. Integrated into cmd/serve.go via a --metrics-bind flag.

## Files Changed
- pkg/metrics/aggregator.go (NEW)
- pkg/metrics/server.go (NEW)
- pkg/metrics/aggregator_test.go (NEW)
- pkg/metrics/server_test.go (NEW)
- cmd/serve.go (MODIFIED)
- _bmad-output/implementation-artifacts/14-1-metrics-endpoint.md (MODIFIED)

## Review Findings
The implementation correctly meets all acceptance criteria. No PII exposed, existing reporter reused. Five patch findings were applied: Encode error handling, security warning for empty-host binds, test cleanup, concurrent test error handling, and fragile test name generation.
- High: 0
- Medium: 2
- Low: 3